### PR TITLE
fix: normalize path separators in workspace member names for Windows

### DIFF
--- a/crates/cmod-workspace/src/workspace.rs
+++ b/crates/cmod-workspace/src/workspace.rs
@@ -311,8 +311,8 @@ fn expand_member_patterns(
                             let name = entry
                                 .strip_prefix(root)
                                 .unwrap_or(&entry)
-                                .display()
-                                .to_string();
+                                .to_string_lossy()
+                                .replace('\\', "/");
                             results.push((name, entry));
                         }
                     }


### PR DESCRIPTION
## Summary

<!-- Brief description of what this PR does and why. -->

## Changes

<!-- List the key changes made in this PR. -->

-

## Testing

- [ ] `cargo test --all` passes
- [ ] `cargo clippy --all-targets -- -D warnings` reports no warnings
- [ ] `cargo fmt --all --check` passes
- [ ] New functionality includes tests

## Related Issues

<!-- Link any related issues: Fixes #123, Relates to #456 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved path handling consistency across platforms by normalizing path separators to forward slashes in member name resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->