### PR TITLE
feat: comprehensive cmod fmt & cmod lint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 **cmod** is a Cargo-inspired, Git-native package and build tool for modern C++20+ modules. It provides dependency resolution, build orchestration, workspace management, and caching — all without a central package registry.
 
-**Status:** Initial Rust implementation (Phase 0-2). The Cargo workspace compiles and has 270+ passing tests. The 21 RFCs and design documents under `docs/` remain the canonical specification.
+**Status:** Rust implementation (Phase 0-4 complete, Phase 5 in progress). The Cargo workspace compiles and has 750+ passing tests. The 21 RFCs and design documents under `docs/` remain the canonical specification.
 
 **Implementation language:** Rust (with LLVM/Clang C++ APIs for build hooks).
 
@@ -252,9 +252,9 @@ Module names follow reverse-domain Git path format: `com.github.user.my_math`.
 | 0 — Foundations | **Implemented** | `cmod.toml` parser, Git resolver, lockfile, CLI commands |
 | 1 — Builds | **Implemented** | LLVM/Clang backend, module DAG, build plan IR, build runner |
 | 2 — Scale | **Implemented** | Workspace manager, local cache, cache keys |
-| 3 — Distributed | Planned | Remote cache protocol, artifact upload/download |
-| 4 — Security | Planned | Signature verification, `--locked --verify` modes |
-| 5 — Ecosystem | Planned | LSP integration, plugin SDK, visualization tools |
+| 3 — Distributed | **Implemented** | Remote cache protocol (HTTP), artifact push/pull, BMI distribution |
+| 4 — Security | **Implemented** | GPG/SSH/Sigstore signing, TOFU trust model, `--locked --verify` modes |
+| 5 — Ecosystem | **In Progress** | LSP server, plugin SDK with sandbox, graph visualization (ASCII/DOT/JSON) |
 
 ## RFC Tiers
 

--- a/README.md
+++ b/README.md
@@ -237,9 +237,9 @@ Key data flows:
 | 0 — Foundations | Done | `cmod.toml` parser, Git resolver, lockfile, CLI |
 | 1 — Builds | Done | LLVM/Clang backend, module DAG, build runner |
 | 2 — Scale | Done | Workspace manager, local cache, cache keys |
-| 3 — Distributed | Planned | Remote cache protocol, artifact upload/download |
-| 4 — Security | Planned | Signature verification, `--locked --verify` modes |
-| 5 — Ecosystem | Planned | LSP integration, plugin SDK, visualization tools |
+| 3 — Distributed | Done | Remote cache protocol (HTTP), artifact push/pull, BMI distribution |
+| 4 — Security | Done | GPG/SSH/Sigstore signing, TOFU trust model, `--locked --verify` modes |
+| 5 — Ecosystem | In Progress | LSP server, plugin SDK with sandbox, graph visualization (ASCII/DOT/JSON) |
 
 ## Contributing
 

--- a/crates/cmod-cli/src/commands/fmt.rs
+++ b/crates/cmod-cli/src/commands/fmt.rs
@@ -2,14 +2,24 @@ use cmod_build::runner;
 use cmod_core::config::Config;
 use cmod_core::error::CmodError;
 use cmod_core::shell::Shell;
+use cmod_workspace::WorkspaceManager;
 
 /// Run `cmod fmt` — format C++ module sources using clang-format.
-pub fn run(check: bool, shell: &Shell) -> Result<(), CmodError> {
+pub fn run(check: bool, package: Option<String>, shell: &Shell) -> Result<(), CmodError> {
     let cwd = std::env::current_dir()?;
     let config = Config::load(&cwd)?;
 
-    let src_dirs = config.src_dirs();
-    let exclude = config.exclude_patterns();
+    if config.manifest.is_workspace() {
+        return fmt_workspace(&config, check, package, shell);
+    }
+
+    fmt_project(&config, check, shell)
+}
+
+/// Format a single (non-workspace) project.
+fn fmt_project(config: &Config, check: bool, shell: &Shell) -> Result<(), CmodError> {
+    let src_dirs = config.format_dirs();
+    let exclude = config.format_exclude();
     let sources = runner::discover_sources_multi(&src_dirs, &exclude)?;
 
     if sources.is_empty() {
@@ -17,7 +27,6 @@ pub fn run(check: bool, shell: &Shell) -> Result<(), CmodError> {
         return Ok(());
     }
 
-    // Check if clang-format is available
     if !is_clang_format_available() {
         return Err(CmodError::CompilerNotFound {
             compiler: "clang-format (install LLVM toolchain)".to_string(),
@@ -38,7 +47,6 @@ pub fn run(check: bool, shell: &Shell) -> Result<(), CmodError> {
             .unwrap_or("unknown");
 
         if check {
-            // --dry-run mode: check if file needs formatting
             let output = std::process::Command::new("clang-format")
                 .arg("--dry-run")
                 .arg("--Werror")
@@ -53,7 +61,6 @@ pub fn run(check: bool, shell: &Shell) -> Result<(), CmodError> {
                 shell.verbose("Unformatted", filename);
             }
         } else {
-            // In-place formatting
             let status = std::process::Command::new("clang-format")
                 .arg("-i")
                 .arg(source)
@@ -91,6 +98,71 @@ pub fn run(check: bool, shell: &Shell) -> Result<(), CmodError> {
     Ok(())
 }
 
+/// Format all workspace members (or a specific `--package`).
+fn fmt_workspace(
+    config: &Config,
+    check: bool,
+    package: Option<String>,
+    shell: &Shell,
+) -> Result<(), CmodError> {
+    let ws = WorkspaceManager::load(&config.root)?;
+
+    let members: Vec<_> = if let Some(ref name) = package {
+        let m =
+            ws.members.iter().find(|m| m.name == *name).ok_or_else(|| {
+                CmodError::Other(format!("workspace member '{}' not found", name))
+            })?;
+        vec![m]
+    } else {
+        ws.members.iter().collect()
+    };
+
+    let mut total_checked = 0usize;
+    let mut total_unformatted = 0usize;
+    let mut any_error = false;
+
+    for member in &members {
+        let member_config = super::util::create_member_config(config, member)?;
+        shell.status(if check { "Checking" } else { "Formatting" }, &member.name);
+
+        match fmt_project(&member_config, check, shell) {
+            Ok(()) => {}
+            Err(CmodError::BuildFailed { ref reason }) if check => {
+                // Parse out the count from the error message
+                if let Some(count_str) = reason.split(' ').next() {
+                    if let Ok(n) = count_str.parse::<usize>() {
+                        total_unformatted += n;
+                    }
+                }
+                any_error = true;
+            }
+            Err(e) => return Err(e),
+        }
+
+        let src_dirs = member_config.format_dirs();
+        let exclude = member_config.format_exclude();
+        let sources = runner::discover_sources_multi(&src_dirs, &exclude).unwrap_or_default();
+        total_checked += sources.len();
+    }
+
+    if check && any_error {
+        return Err(CmodError::BuildFailed {
+            reason: format!(
+                "{} file(s) need formatting across {} member(s)",
+                total_unformatted,
+                members.len()
+            ),
+        });
+    }
+
+    shell.status(
+        "Finished",
+        format!("{} files across {} member(s)", total_checked, members.len()),
+    );
+
+    Ok(())
+}
+
 /// Check if `clang-format` is available on PATH.
 fn is_clang_format_available() -> bool {
     std::process::Command::new("clang-format")
@@ -105,8 +177,6 @@ fn is_clang_format_available() -> bool {
 mod tests {
     #[test]
     fn test_clang_format_check_concept() {
-        // Verifies the module compiles and basic types work.
-        // Actual clang-format invocation tested in integration tests.
         let check = true;
         let label = if check { "Checking" } else { "Formatting" };
         assert_eq!(label, "Checking");

--- a/crates/cmod-cli/src/commands/init.rs
+++ b/crates/cmod-cli/src/commands/init.rs
@@ -112,11 +112,21 @@ fn init_module(dir: &Path, name: &str, shell: &Shell) -> Result<(), CmodError> {
         ),
     )?;
 
+    // Create .clang-format if it doesn't exist
+    let clang_format_path = dir.join(".clang-format");
+    if !clang_format_path.exists() {
+        std::fs::write(
+            &clang_format_path,
+            "BasedOnStyle: LLVM\nIndentWidth: 4\nColumnLimit: 120\n",
+        )?;
+    }
+
     shell.status("Created", format!("module '{}' in {}", name, dir.display()));
     shell.verbose("Created", "cmod.toml");
     shell.verbose("Created", "src/lib.cppm");
     shell.verbose("Created", "src/main.cpp");
     shell.verbose("Created", "tests/main.cpp");
+    shell.verbose("Created", ".clang-format");
 
     Ok(())
 }

--- a/crates/cmod-cli/src/commands/lint.rs
+++ b/crates/cmod-cli/src/commands/lint.rs
@@ -2,22 +2,47 @@ use cmod_build::runner;
 use cmod_core::config::Config;
 use cmod_core::error::CmodError;
 use cmod_core::shell::Shell;
+use cmod_workspace::WorkspaceManager;
 
 /// Run `cmod lint` — static analysis and style checks on C++ module sources.
-pub fn run(shell: &Shell) -> Result<(), CmodError> {
+pub fn run(deny_warnings: bool, package: Option<String>, shell: &Shell) -> Result<(), CmodError> {
     let cwd = std::env::current_dir()?;
     let config = Config::load(&cwd)?;
 
+    if config.manifest.is_workspace() {
+        return lint_workspace(&config, deny_warnings, package, shell);
+    }
+
+    lint_project(&config, deny_warnings, shell)?;
+    Ok(())
+}
+
+/// Lint a single (non-workspace) project. Returns the number of warnings found.
+fn lint_project(config: &Config, deny_warnings: bool, shell: &Shell) -> Result<usize, CmodError> {
     shell.status("Linting", &config.manifest.package.name);
 
-    let src_dirs = config.src_dirs();
-    let exclude = config.exclude_patterns();
+    let src_dirs = config.lint_dirs();
+    let exclude = config.lint_exclude();
     let sources = runner::discover_sources_multi(&src_dirs, &exclude)?;
 
     if sources.is_empty() {
         shell.warn("no source files found");
-        return Ok(());
+        return Ok(0);
     }
+
+    let max_line_length = config
+        .manifest
+        .lint
+        .as_ref()
+        .and_then(|l| l.max_line_length)
+        .unwrap_or(120);
+
+    let clang_tidy_enabled = config
+        .manifest
+        .lint
+        .as_ref()
+        .and_then(|l| l.clang_tidy)
+        .unwrap_or(false);
 
     let mut warnings = Vec::new();
 
@@ -28,12 +53,20 @@ pub fn run(shell: &Shell) -> Result<(), CmodError> {
             .and_then(|f| f.to_str())
             .unwrap_or("unknown");
 
-        let file_warnings = lint_source(filename, &content);
+        let file_warnings = lint_source(filename, &content, max_line_length);
         for w in &file_warnings {
-            shell.verbose("Warning", format!("{}:{}: {}", filename, w.line, w.message));
+            shell.warn(format!("{}:{}: {}", w.filename, w.line, w.message));
         }
         warnings.extend(file_warnings);
+
+        // Run clang-tidy if enabled
+        if clang_tidy_enabled {
+            let tidy_warnings = run_clang_tidy(source, shell)?;
+            warnings.extend(tidy_warnings);
+        }
     }
+
+    let warning_count = warnings.len();
 
     if warnings.is_empty() {
         shell.status(
@@ -43,8 +76,68 @@ pub fn run(shell: &Shell) -> Result<(), CmodError> {
     } else {
         shell.status(
             "Finished",
-            format!("{} warning(s) in {} file(s)", warnings.len(), sources.len()),
+            format!("{} warning(s) in {} file(s)", warning_count, sources.len()),
         );
+    }
+
+    if deny_warnings && warning_count > 0 {
+        return Err(CmodError::BuildFailed {
+            reason: format!(
+                "lint failed: {} warning(s) found (--deny-warnings)",
+                warning_count
+            ),
+        });
+    }
+
+    Ok(warning_count)
+}
+
+/// Lint all workspace members (or a specific `--package`).
+fn lint_workspace(
+    config: &Config,
+    deny_warnings: bool,
+    package: Option<String>,
+    shell: &Shell,
+) -> Result<(), CmodError> {
+    let ws = WorkspaceManager::load(&config.root)?;
+
+    let members: Vec<_> = if let Some(ref name) = package {
+        let m =
+            ws.members.iter().find(|m| m.name == *name).ok_or_else(|| {
+                CmodError::Other(format!("workspace member '{}' not found", name))
+            })?;
+        vec![m]
+    } else {
+        ws.members.iter().collect()
+    };
+
+    let mut total_warnings = 0usize;
+    let mut total_files = 0usize;
+
+    for member in &members {
+        let member_config = super::util::create_member_config(config, member)?;
+
+        let src_dirs = member_config.lint_dirs();
+        let exclude = member_config.lint_exclude();
+        let sources = runner::discover_sources_multi(&src_dirs, &exclude).unwrap_or_default();
+        total_files += sources.len();
+
+        let count = lint_project(&member_config, false, shell)?;
+        total_warnings += count;
+    }
+
+    shell.status(
+        "Finished",
+        format!("{} file(s) across {} member(s)", total_files, members.len()),
+    );
+
+    if deny_warnings && total_warnings > 0 {
+        return Err(CmodError::BuildFailed {
+            reason: format!(
+                "lint failed: {} warning(s) across workspace (--deny-warnings)",
+                total_warnings
+            ),
+        });
     }
 
     Ok(())
@@ -53,12 +146,13 @@ pub fn run(shell: &Shell) -> Result<(), CmodError> {
 /// A lint warning with location info.
 #[derive(Debug)]
 struct LintWarning {
+    filename: String,
     line: usize,
     message: String,
 }
 
 /// Check a source file for common issues.
-fn lint_source(filename: &str, content: &str) -> Vec<LintWarning> {
+fn lint_source(filename: &str, content: &str, max_line_length: usize) -> Vec<LintWarning> {
     let mut warnings = Vec::new();
 
     for (i, line) in content.lines().enumerate() {
@@ -67,6 +161,7 @@ fn lint_source(filename: &str, content: &str) -> Vec<LintWarning> {
         // Check for trailing whitespace
         if line != line.trim_end() && !line.trim().is_empty() {
             warnings.push(LintWarning {
+                filename: filename.to_string(),
                 line: lineno,
                 message: "trailing whitespace".to_string(),
             });
@@ -75,22 +170,29 @@ fn lint_source(filename: &str, content: &str) -> Vec<LintWarning> {
         // Check for tabs (prefer spaces in module sources)
         if line.contains('\t') {
             warnings.push(LintWarning {
+                filename: filename.to_string(),
                 line: lineno,
                 message: "tab character found (prefer spaces)".to_string(),
             });
         }
 
         // Check for very long lines
-        if line.len() > 120 {
+        if line.len() > max_line_length {
             warnings.push(LintWarning {
+                filename: filename.to_string(),
                 line: lineno,
-                message: format!("line too long ({} chars, max 120)", line.len()),
+                message: format!(
+                    "line too long ({} chars, max {})",
+                    line.len(),
+                    max_line_length
+                ),
             });
         }
 
         // Check for `#pragma once` in module files (not needed for modules)
         if line.trim() == "#pragma once" && is_module_file(filename) {
             warnings.push(LintWarning {
+                filename: filename.to_string(),
                 line: lineno,
                 message: "#pragma once is unnecessary in module files".to_string(),
             });
@@ -99,15 +201,16 @@ fn lint_source(filename: &str, content: &str) -> Vec<LintWarning> {
         // Check for `using namespace std;` at global scope
         if line.trim() == "using namespace std;" {
             warnings.push(LintWarning {
+                filename: filename.to_string(),
                 line: lineno,
                 message: "avoid 'using namespace std;' at global scope".to_string(),
             });
         }
 
         // Check for C-style casts in module files
-        // Simple heuristic: (Type) pattern not preceded by common keywords
         if is_module_file(filename) && has_c_style_cast(line) {
             warnings.push(LintWarning {
+                filename: filename.to_string(),
                 line: lineno,
                 message: "possible C-style cast; prefer static_cast/dynamic_cast".to_string(),
             });
@@ -117,12 +220,64 @@ fn lint_source(filename: &str, content: &str) -> Vec<LintWarning> {
     // Check for missing newline at end of file
     if !content.is_empty() && !content.ends_with('\n') {
         warnings.push(LintWarning {
+            filename: filename.to_string(),
             line: content.lines().count(),
             message: "file does not end with a newline".to_string(),
         });
     }
 
     warnings
+}
+
+/// Run clang-tidy on a single source file and collect warnings.
+fn run_clang_tidy(source: &std::path::Path, shell: &Shell) -> Result<Vec<LintWarning>, CmodError> {
+    if !is_clang_tidy_available() {
+        shell.warn("clang-tidy not found; skipping clang-tidy checks");
+        return Ok(Vec::new());
+    }
+
+    let output = std::process::Command::new("clang-tidy")
+        .arg(source)
+        .arg("--")
+        .output()
+        .map_err(|e| CmodError::BuildFailed {
+            reason: format!("failed to run clang-tidy: {}", e),
+        })?;
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let combined = format!("{}{}", stdout, stderr);
+
+    let filename = source
+        .file_name()
+        .and_then(|f| f.to_str())
+        .unwrap_or("unknown");
+
+    let mut warnings = Vec::new();
+
+    // Parse clang-tidy output: "file:line:col: warning: message [check-name]"
+    for line in combined.lines() {
+        if let Some(warning_idx) = line.find(": warning:") {
+            let location = &line[..warning_idx];
+            let message = line[warning_idx + ": warning: ".len()..].trim();
+
+            let lineno = location
+                .rsplit(':')
+                .nth(1)
+                .and_then(|s| s.parse::<usize>().ok())
+                .unwrap_or(0);
+
+            shell.warn(format!("{}:{}: [clang-tidy] {}", filename, lineno, message));
+
+            warnings.push(LintWarning {
+                filename: filename.to_string(),
+                line: lineno,
+                message: format!("[clang-tidy] {}", message),
+            });
+        }
+    }
+
+    Ok(warnings)
 }
 
 /// Check if a filename represents a C++ module file.
@@ -138,7 +293,6 @@ fn has_c_style_cast(line: &str) -> bool {
         return false;
     }
 
-    // Look for patterns like (int), (double), (char*) that aren't function calls
     let cast_types = [
         "int", "float", "double", "char", "long", "short", "unsigned", "void",
     ];
@@ -155,6 +309,16 @@ fn has_c_style_cast(line: &str) -> bool {
     false
 }
 
+/// Check if `clang-tidy` is available on PATH.
+fn is_clang_tidy_available() -> bool {
+    std::process::Command::new("clang-tidy")
+        .arg("--version")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .is_ok_and(|s| s.success())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -162,14 +326,14 @@ mod tests {
     #[test]
     fn test_lint_clean_source() {
         let content = "export module mymod;\n\nvoid hello() {}\n";
-        let warnings = lint_source("test.cppm", content);
+        let warnings = lint_source("test.cppm", content, 120);
         assert!(warnings.is_empty());
     }
 
     #[test]
     fn test_lint_trailing_whitespace() {
         let content = "int x = 1;  \n";
-        let warnings = lint_source("test.cpp", content);
+        let warnings = lint_source("test.cpp", content, 120);
         assert!(warnings
             .iter()
             .any(|w| w.message.contains("trailing whitespace")));
@@ -178,35 +342,51 @@ mod tests {
     #[test]
     fn test_lint_tab_character() {
         let content = "\tint x = 1;\n";
-        let warnings = lint_source("test.cpp", content);
+        let warnings = lint_source("test.cpp", content, 120);
         assert!(warnings.iter().any(|w| w.message.contains("tab character")));
     }
 
     #[test]
     fn test_lint_long_line() {
         let content = format!("{}\n", "x".repeat(130));
-        let warnings = lint_source("test.cpp", &content);
+        let warnings = lint_source("test.cpp", &content, 120);
         assert!(warnings.iter().any(|w| w.message.contains("line too long")));
+    }
+
+    #[test]
+    fn test_lint_long_line_custom_max() {
+        let content = format!("{}\n", "x".repeat(90));
+        let warnings = lint_source("test.cpp", &content, 80);
+        assert!(warnings
+            .iter()
+            .any(|w| w.message.contains("line too long") && w.message.contains("max 80")));
+    }
+
+    #[test]
+    fn test_lint_long_line_custom_max_ok() {
+        let content = format!("{}\n", "x".repeat(90));
+        let warnings = lint_source("test.cpp", &content, 200);
+        assert!(!warnings.iter().any(|w| w.message.contains("line too long")));
     }
 
     #[test]
     fn test_lint_pragma_once_in_module() {
         let content = "#pragma once\nexport module mymod;\n";
-        let warnings = lint_source("test.cppm", content);
+        let warnings = lint_source("test.cppm", content, 120);
         assert!(warnings.iter().any(|w| w.message.contains("#pragma once")));
     }
 
     #[test]
     fn test_lint_pragma_once_in_header_ok() {
         let content = "#pragma once\nint x = 1;\n";
-        let warnings = lint_source("test.hpp", content);
+        let warnings = lint_source("test.hpp", content, 120);
         assert!(!warnings.iter().any(|w| w.message.contains("#pragma once")));
     }
 
     #[test]
     fn test_lint_using_namespace_std() {
         let content = "using namespace std;\nint main() {}\n";
-        let warnings = lint_source("test.cpp", content);
+        let warnings = lint_source("test.cpp", content, 120);
         assert!(warnings
             .iter()
             .any(|w| w.message.contains("using namespace std")));
@@ -215,7 +395,7 @@ mod tests {
     #[test]
     fn test_lint_no_trailing_newline() {
         let content = "int main() {}";
-        let warnings = lint_source("test.cpp", content);
+        let warnings = lint_source("test.cpp", content, 120);
         assert!(warnings.iter().any(|w| w.message.contains("newline")));
     }
 
@@ -235,5 +415,12 @@ mod tests {
         assert!(!has_c_style_cast("auto y = static_cast<int>(x);"));
         assert!(!has_c_style_cast("// (int) comment"));
         assert!(!has_c_style_cast("#define X (int)"));
+    }
+
+    #[test]
+    fn test_lint_warning_has_filename() {
+        let content = "int x = 1;  \n";
+        let warnings = lint_source("myfile.cpp", content, 120);
+        assert!(warnings.iter().all(|w| w.filename == "myfile.cpp"));
     }
 }

--- a/crates/cmod-cli/src/commands/mod.rs
+++ b/crates/cmod-cli/src/commands/mod.rs
@@ -25,6 +25,7 @@ pub mod test;
 pub mod tidy;
 pub mod toolchain;
 pub mod update;
+pub mod util;
 pub mod vendor;
 pub mod verify;
 pub mod workspace;

--- a/crates/cmod-cli/src/commands/test.rs
+++ b/crates/cmod-cli/src/commands/test.rs
@@ -1093,7 +1093,7 @@ fn test_workspace(config: &Config, shell: &Shell, opts: &TestOptions) -> Result<
         }
 
         // Create a member-scoped config
-        let member_config = create_member_config(config, member)?;
+        let member_config = super::util::create_member_config(config, member)?;
 
         match test_single_project(&member_config, shell, opts) {
             Ok(summary) => {
@@ -1164,33 +1164,6 @@ fn test_workspace(config: &Config, shell: &Shell, opts: &TestOptions) -> Result<
             count: overall_summary.failed + overall_summary.timed_out,
         })
     }
-}
-
-fn create_member_config(
-    parent_config: &Config,
-    member: &cmod_workspace::workspace::WorkspaceMember,
-) -> Result<Config, CmodError> {
-    let manifest_path = member.path.join("cmod.toml");
-    let manifest = if manifest_path.exists() {
-        cmod_core::manifest::Manifest::load(&manifest_path)?
-    } else {
-        member.manifest.clone()
-    };
-
-    Ok(Config {
-        root: member.path.clone(),
-        manifest_path: manifest_path.clone(),
-        manifest,
-        lockfile_path: parent_config.lockfile_path.clone(),
-        profile: parent_config.profile,
-        target: parent_config.target.clone(),
-        locked: parent_config.locked,
-        offline: parent_config.offline,
-        verbosity: parent_config.verbosity,
-        enabled_features: parent_config.enabled_features.clone(),
-        no_default_features: parent_config.no_default_features,
-        no_cache: parent_config.no_cache,
-    })
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/cmod-cli/src/commands/util.rs
+++ b/crates/cmod-cli/src/commands/util.rs
@@ -1,0 +1,30 @@
+use cmod_core::config::Config;
+use cmod_core::error::CmodError;
+
+/// Create a `Config` scoped to a single workspace member.
+pub fn create_member_config(
+    parent_config: &Config,
+    member: &cmod_workspace::workspace::WorkspaceMember,
+) -> Result<Config, CmodError> {
+    let manifest_path = member.path.join("cmod.toml");
+    let manifest = if manifest_path.exists() {
+        cmod_core::manifest::Manifest::load(&manifest_path)?
+    } else {
+        member.manifest.clone()
+    };
+
+    Ok(Config {
+        root: member.path.clone(),
+        manifest_path: manifest_path.clone(),
+        manifest,
+        lockfile_path: parent_config.lockfile_path.clone(),
+        profile: parent_config.profile,
+        target: parent_config.target.clone(),
+        locked: parent_config.locked,
+        offline: parent_config.offline,
+        verbosity: parent_config.verbosity,
+        enabled_features: parent_config.enabled_features.clone(),
+        no_default_features: parent_config.no_default_features,
+        no_cache: parent_config.no_cache,
+    })
+}

--- a/crates/cmod-cli/src/main.rs
+++ b/crates/cmod-cli/src/main.rs
@@ -280,13 +280,25 @@ enum Commands {
     },
 
     /// Lint C++ source files for common issues
-    Lint,
+    Lint {
+        /// Treat warnings as errors (non-zero exit code if any warnings)
+        #[arg(long)]
+        deny_warnings: bool,
+
+        /// Lint a specific workspace member
+        #[arg(short, long)]
+        package: Option<String>,
+    },
 
     /// Format C++ source files using clang-format
     Fmt {
         /// Check formatting without modifying files
         #[arg(long)]
         check: bool,
+
+        /// Format a specific workspace member
+        #[arg(short, long)]
+        package: Option<String>,
     },
 
     /// Search for modules by name
@@ -582,8 +594,11 @@ fn main() {
             ToolchainAction::Check => commands::toolchain::check(&shell),
         },
         Commands::Vendor { sync } => commands::vendor::run(sync, &shell),
-        Commands::Lint => commands::lint::run(&shell),
-        Commands::Fmt { check } => commands::fmt::run(check, &shell),
+        Commands::Lint {
+            deny_warnings,
+            package,
+        } => commands::lint::run(deny_warnings, package, &shell),
+        Commands::Fmt { check, package } => commands::fmt::run(check, package, &shell),
         Commands::Search { query, local_only } => {
             commands::search::run(&query, local_only, cli.offline, &shell)
         }

--- a/crates/cmod-core/src/config.rs
+++ b/crates/cmod-core/src/config.rs
@@ -124,6 +124,60 @@ impl Config {
             .map(|b| b.exclude.clone())
             .unwrap_or_default()
     }
+
+    /// Directories to format: src_dirs() + tests/ + [format].include_dirs.
+    pub fn format_dirs(&self) -> Vec<PathBuf> {
+        let mut dirs = self.src_dirs();
+        let tests_dir = self.root.join("tests");
+        if tests_dir.is_dir() && !dirs.contains(&tests_dir) {
+            dirs.push(tests_dir);
+        }
+        if let Some(ref fmt) = self.manifest.format {
+            for d in &fmt.include_dirs {
+                let p = self.root.join(d);
+                if !dirs.contains(&p) {
+                    dirs.push(p);
+                }
+            }
+        }
+        dirs
+    }
+
+    /// Exclude patterns for formatting.
+    pub fn format_exclude(&self) -> Vec<String> {
+        self.manifest
+            .format
+            .as_ref()
+            .map(|f| f.exclude.clone())
+            .unwrap_or_default()
+    }
+
+    /// Directories to lint: src_dirs() + tests/ + [lint].include_dirs.
+    pub fn lint_dirs(&self) -> Vec<PathBuf> {
+        let mut dirs = self.src_dirs();
+        let tests_dir = self.root.join("tests");
+        if tests_dir.is_dir() && !dirs.contains(&tests_dir) {
+            dirs.push(tests_dir);
+        }
+        if let Some(ref lint) = self.manifest.lint {
+            for d in &lint.include_dirs {
+                let p = self.root.join(d);
+                if !dirs.contains(&p) {
+                    dirs.push(p);
+                }
+            }
+        }
+        dirs
+    }
+
+    /// Exclude patterns for linting.
+    pub fn lint_exclude(&self) -> Vec<String> {
+        self.manifest
+            .lint
+            .as_ref()
+            .map(|l| l.exclude.clone())
+            .unwrap_or_default()
+    }
 }
 
 #[cfg(test)]
@@ -265,5 +319,118 @@ local_path = "/custom/cache"
 
         let config = Config::load(tmp.path()).unwrap();
         assert_eq!(config.cache_dir(), PathBuf::from("/custom/cache"));
+    }
+
+    #[test]
+    fn test_format_dirs_default() {
+        let tmp = setup_project();
+        // Create tests/ dir so it gets included
+        std::fs::create_dir_all(tmp.path().join("tests")).unwrap();
+        let config = Config::load(tmp.path()).unwrap();
+        let dirs = config.format_dirs();
+        assert!(dirs.contains(&tmp.path().join("src")));
+        assert!(dirs.contains(&tmp.path().join("tests")));
+    }
+
+    #[test]
+    fn test_format_dirs_no_tests_dir() {
+        let tmp = setup_project();
+        let config = Config::load(tmp.path()).unwrap();
+        let dirs = config.format_dirs();
+        assert!(dirs.contains(&tmp.path().join("src")));
+        // tests/ doesn't exist, so it shouldn't be included
+        assert!(!dirs.contains(&tmp.path().join("tests")));
+    }
+
+    #[test]
+    fn test_format_dirs_with_include_dirs() {
+        let tmp = TempDir::new().unwrap();
+        let toml = r#"
+[package]
+name = "test"
+version = "0.1.0"
+
+[format]
+include_dirs = ["benchmarks"]
+"#;
+        std::fs::write(tmp.path().join("cmod.toml"), toml).unwrap();
+        let config = Config::load(tmp.path()).unwrap();
+        let dirs = config.format_dirs();
+        assert!(dirs.contains(&tmp.path().join("src")));
+        assert!(dirs.contains(&tmp.path().join("benchmarks")));
+    }
+
+    #[test]
+    fn test_lint_dirs_default() {
+        let tmp = setup_project();
+        std::fs::create_dir_all(tmp.path().join("tests")).unwrap();
+        let config = Config::load(tmp.path()).unwrap();
+        let dirs = config.lint_dirs();
+        assert!(dirs.contains(&tmp.path().join("src")));
+        assert!(dirs.contains(&tmp.path().join("tests")));
+    }
+
+    #[test]
+    fn test_lint_dirs_with_include_dirs() {
+        let tmp = TempDir::new().unwrap();
+        let toml = r#"
+[package]
+name = "test"
+version = "0.1.0"
+
+[lint]
+include_dirs = ["examples"]
+"#;
+        std::fs::write(tmp.path().join("cmod.toml"), toml).unwrap();
+        let config = Config::load(tmp.path()).unwrap();
+        let dirs = config.lint_dirs();
+        assert!(dirs.contains(&tmp.path().join("src")));
+        assert!(dirs.contains(&tmp.path().join("examples")));
+    }
+
+    #[test]
+    fn test_format_exclude() {
+        let tmp = TempDir::new().unwrap();
+        let toml = r#"
+[package]
+name = "test"
+version = "0.1.0"
+
+[format]
+exclude = ["generated/**", "vendor/**"]
+"#;
+        std::fs::write(tmp.path().join("cmod.toml"), toml).unwrap();
+        let config = Config::load(tmp.path()).unwrap();
+        assert_eq!(config.format_exclude(), vec!["generated/**", "vendor/**"]);
+    }
+
+    #[test]
+    fn test_lint_exclude() {
+        let tmp = TempDir::new().unwrap();
+        let toml = r#"
+[package]
+name = "test"
+version = "0.1.0"
+
+[lint]
+exclude = ["third_party/**"]
+"#;
+        std::fs::write(tmp.path().join("cmod.toml"), toml).unwrap();
+        let config = Config::load(tmp.path()).unwrap();
+        assert_eq!(config.lint_exclude(), vec!["third_party/**"]);
+    }
+
+    #[test]
+    fn test_format_exclude_default_empty() {
+        let tmp = setup_project();
+        let config = Config::load(tmp.path()).unwrap();
+        assert!(config.format_exclude().is_empty());
+    }
+
+    #[test]
+    fn test_lint_exclude_default_empty() {
+        let tmp = setup_project();
+        let config = Config::load(tmp.path()).unwrap();
+        assert!(config.lint_exclude().is_empty());
     }
 }

--- a/crates/cmod-core/src/manifest.rs
+++ b/crates/cmod-core/src/manifest.rs
@@ -38,6 +38,12 @@ pub struct Manifest {
     pub test: Option<Test>,
 
     #[serde(default)]
+    pub format: Option<Format>,
+
+    #[serde(default)]
+    pub lint: Option<Lint>,
+
+    #[serde(default)]
     pub workspace: Option<Workspace>,
 
     #[serde(default)]
@@ -281,6 +287,34 @@ pub struct Test {
     /// Default per-test timeout in seconds (overridden by CLI --timeout).
     #[serde(default)]
     pub timeout: Option<u64>,
+}
+
+/// Formatting configuration (`[format]` section in cmod.toml).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Format {
+    /// Additional directories to format (merged with src_dirs).
+    #[serde(default)]
+    pub include_dirs: Vec<String>,
+    /// Glob patterns to exclude from formatting.
+    #[serde(default)]
+    pub exclude: Vec<String>,
+}
+
+/// Linting configuration (`[lint]` section in cmod.toml).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Lint {
+    /// Additional directories to lint (merged with src_dirs).
+    #[serde(default)]
+    pub include_dirs: Vec<String>,
+    /// Glob patterns to exclude from linting.
+    #[serde(default)]
+    pub exclude: Vec<String>,
+    /// Maximum line length for the "line too long" rule. Default: 120.
+    #[serde(default)]
+    pub max_line_length: Option<usize>,
+    /// Enable clang-tidy integration.
+    #[serde(default)]
+    pub clang_tidy: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -830,6 +864,8 @@ pub fn default_manifest(name: &str) -> Manifest {
             distributed: None,
         }),
         test: None,
+        format: None,
+        lint: None,
         workspace: None,
         cache: None,
         metadata: None,
@@ -865,6 +901,8 @@ pub fn default_workspace_manifest(name: &str) -> Manifest {
         toolchain: None,
         build: None,
         test: None,
+        format: None,
+        lint: None,
         workspace: Some(Workspace {
             name: Some(name.to_string()),
             version: None,
@@ -1351,5 +1389,67 @@ win-only = "^3.0"
             r#"cfg(target_env = "musl")"#,
             "x86_64-unknown-linux-gnu"
         ));
+    }
+
+    #[test]
+    fn test_parse_format_section() {
+        let toml_str = r#"
+[package]
+name = "test"
+version = "0.1.0"
+
+[format]
+include_dirs = ["benchmarks", "examples"]
+exclude = ["generated/**"]
+"#;
+        let manifest = Manifest::from_str(toml_str).unwrap();
+        let fmt = manifest.format.unwrap();
+        assert_eq!(fmt.include_dirs, vec!["benchmarks", "examples"]);
+        assert_eq!(fmt.exclude, vec!["generated/**"]);
+    }
+
+    #[test]
+    fn test_parse_lint_section() {
+        let toml_str = r#"
+[package]
+name = "test"
+version = "0.1.0"
+
+[lint]
+include_dirs = ["benchmarks"]
+exclude = ["vendor/**"]
+max_line_length = 100
+clang_tidy = true
+"#;
+        let manifest = Manifest::from_str(toml_str).unwrap();
+        let lint = manifest.lint.unwrap();
+        assert_eq!(lint.include_dirs, vec!["benchmarks"]);
+        assert_eq!(lint.exclude, vec!["vendor/**"]);
+        assert_eq!(lint.max_line_length, Some(100));
+        assert_eq!(lint.clang_tidy, Some(true));
+    }
+
+    #[test]
+    fn test_parse_lint_defaults() {
+        let toml_str = r#"
+[package]
+name = "test"
+version = "0.1.0"
+
+[lint]
+"#;
+        let manifest = Manifest::from_str(toml_str).unwrap();
+        let lint = manifest.lint.unwrap();
+        assert!(lint.include_dirs.is_empty());
+        assert!(lint.exclude.is_empty());
+        assert_eq!(lint.max_line_length, None);
+        assert_eq!(lint.clang_tidy, None);
+    }
+
+    #[test]
+    fn test_format_and_lint_absent_by_default() {
+        let manifest = default_manifest("hello");
+        assert!(manifest.format.is_none());
+        assert!(manifest.lint.is_none());
     }
 }

--- a/crates/cmod-resolver/src/conditional.rs
+++ b/crates/cmod-resolver/src/conditional.rs
@@ -225,6 +225,8 @@ mod tests {
             toolchain: None,
             build: None,
             test: None,
+            format: None,
+            lint: None,
             workspace: None,
             cache: None,
             metadata: None,

--- a/crates/cmod-resolver/src/features.rs
+++ b/crates/cmod-resolver/src/features.rs
@@ -200,6 +200,8 @@ mod tests {
             toolchain: None,
             build: None,
             test: None,
+            format: None,
+            lint: None,
             workspace: None,
             cache: None,
             metadata: None,

--- a/crates/cmod-resolver/src/resolver.rs
+++ b/crates/cmod-resolver/src/resolver.rs
@@ -810,6 +810,8 @@ mod tests {
             toolchain: None,
             build: None,
             test: None,
+            format: None,
+            lint: None,
             workspace: None,
             cache: None,
             metadata: None,

--- a/crates/cmod-security/src/audit.rs
+++ b/crates/cmod-security/src/audit.rs
@@ -175,6 +175,8 @@ mod tests {
             toolchain: None,
             build: None,
             test: None,
+            format: None,
+            lint: None,
             workspace: None,
             cache: None,
             metadata: None,

--- a/docs/guide/cli-reference.md
+++ b/docs/guide/cli-reference.md
@@ -373,23 +373,33 @@ cmod emit-cmake
 
 ### `cmod lint`
 
-Lint C++ source files for common issues using clang-tidy.
+Lint C++ source files for common issues. Checks for trailing whitespace, tabs, long lines, `#pragma once` in modules, `using namespace std;`, C-style casts, and missing final newlines. Optionally integrates with clang-tidy when `[lint].clang_tidy = true` in `cmod.toml`.
+
+Scans `src/` and `tests/` by default plus any directories listed in `[lint].include_dirs`.
 
 ```
-cmod lint
+cmod lint [--deny-warnings] [-p <member>]
 ```
+
+| Option | Description |
+|--------|-------------|
+| `--deny-warnings` | Treat warnings as errors (non-zero exit code if any warnings) |
+| `-p, --package <name>` | Lint a specific workspace member |
 
 ### `cmod fmt`
 
 Format C++ source files using clang-format.
 
+Scans `src/` and `tests/` by default plus any directories listed in `[format].include_dirs`.
+
 ```
-cmod fmt [--check]
+cmod fmt [--check] [-p <member>]
 ```
 
 | Option | Description |
 |--------|-------------|
 | `--check` | Check formatting without modifying files |
+| `-p, --package <name>` | Format a specific workspace member |
 
 ---
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -202,6 +202,44 @@ timeout = 300                                # Per-test timeout in seconds (0 = 
 | `extra_flags` | list | `[]` | Extra compiler flags applied only to test builds |
 | `timeout` | integer | `300` | Per-test timeout in seconds (`0` = no timeout) |
 
+## `[format]`
+
+Formatting configuration for `cmod fmt`.
+
+```toml
+[format]
+include_dirs = ["tests", "benchmarks"]  # Additional directories to format (merged with src_dirs)
+exclude = ["generated/**"]              # Glob patterns to exclude from formatting
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `include_dirs` | list | `[]` | Extra directories to format (in addition to `src/` and `tests/`) |
+| `exclude` | list | `[]` | Glob patterns to exclude from formatting |
+
+By default, `cmod fmt` scans `src/` and `tests/`. Use `include_dirs` to add more directories.
+
+## `[lint]`
+
+Linting configuration for `cmod lint`.
+
+```toml
+[lint]
+include_dirs = ["tests", "benchmarks"]  # Additional directories to lint (merged with src_dirs)
+exclude = ["generated/**"]              # Glob patterns to exclude from linting
+max_line_length = 100                   # Maximum line length (default: 120)
+clang_tidy = true                       # Enable clang-tidy integration (default: false)
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `include_dirs` | list | `[]` | Extra directories to lint (in addition to `src/` and `tests/`) |
+| `exclude` | list | `[]` | Glob patterns to exclude from linting |
+| `max_line_length` | integer | `120` | Maximum line length for the "line too long" rule |
+| `clang_tidy` | boolean | `false` | Enable clang-tidy integration |
+
+By default, `cmod lint` scans `src/` and `tests/`. Use `--deny-warnings` to treat warnings as errors.
+
 ## `[cache]`
 
 Build cache configuration.

--- a/docs/rfc/rfc_unified_cmod_schema.md
+++ b/docs/rfc/rfc_unified_cmod_schema.md
@@ -79,6 +79,18 @@ runner = ""                         # Custom test runner command (empty = direct
 extra_flags = ["-fsanitize=address"] # Extra compiler flags for test builds only
 timeout = 300                       # Per-test timeout in seconds (0 = no timeout)
 
+# === Formatting Configuration ===
+[format]
+include_dirs = ["benchmarks"]       # Extra directories to format (merged with src/ and tests/)
+exclude = ["generated/**"]          # Glob patterns to exclude from formatting
+
+# === Linting Configuration ===
+[lint]
+include_dirs = ["benchmarks"]       # Extra directories to lint (merged with src/ and tests/)
+exclude = ["generated/**"]          # Glob patterns to exclude from linting
+max_line_length = 120               # Maximum line length (default: 120)
+clang_tidy = false                  # Enable clang-tidy integration (default: false)
+
 # === Publishing Configuration ===
 [publish]
 registry = "https://crates.cmod.io" # Future registry URL


### PR DESCRIPTION
This pull request introduces major improvements to the formatting and linting commands in the `cmod-cli` crate, with a focus on better workspace support, configurability, and integration with external tools. The most important changes are summarized below:

**Workspace and Package Support:**

* Both `fmt` and `lint` commands now support formatting/linting all workspace members or a specific package via a new `--package` argument. This is handled by new helper functions (`fmt_workspace`, `lint_workspace`) that iterate over workspace members and aggregate results. [[1]](diffhunk://#diff-4ce24d792eb39246af8ea53e0fae09cb593b9990be7082c3998f214b50e86970R5-L20) [[2]](diffhunk://#diff-147829161485c14ffc689157f96537744eb64c7cba835d037c51ceeee90d65e2R5-R46) [[3]](diffhunk://#diff-4ce24d792eb39246af8ea53e0fae09cb593b9990be7082c3998f214b50e86970R101-R165) [[4]](diffhunk://#diff-147829161485c14ffc689157f96537744eb64c7cba835d037c51ceeee90d65e2L46-R155)

**Configurability and Extensibility:**

* Linting now respects per-project configuration for maximum line length and enables optional `clang-tidy` integration, controlled via config options. The linter also now passes the configured max line length to checks and reports warnings with the filename. [[1]](diffhunk://#diff-147829161485c14ffc689157f96537744eb64c7cba835d037c51ceeee90d65e2R5-R46) [[2]](diffhunk://#diff-147829161485c14ffc689157f96537744eb64c7cba835d037c51ceeee90d65e2L31-R70) [[3]](diffhunk://#diff-147829161485c14ffc689157f96537744eb64c7cba835d037c51ceeee90d65e2L46-R155) [[4]](diffhunk://#diff-147829161485c14ffc689157f96537744eb64c7cba835d037c51ceeee90d65e2R164) [[5]](diffhunk://#diff-147829161485c14ffc689157f96537744eb64c7cba835d037c51ceeee90d65e2R173-R195) [[6]](diffhunk://#diff-147829161485c14ffc689157f96537744eb64c7cba835d037c51ceeee90d65e2R204-R213) [[7]](diffhunk://#diff-147829161485c14ffc689157f96537744eb64c7cba835d037c51ceeee90d65e2R223) [[8]](diffhunk://#diff-147829161485c14ffc689157f96537744eb64c7cba835d037c51ceeee90d65e2R232-R282)

**Improved User Feedback and Error Handling:**

* The commands now provide more detailed status and error messages, including totals for files checked/formatted and warnings found. The `--deny-warnings` option in `lint` now fails the build if any warnings are present, both for single projects and across workspaces. [[1]](diffhunk://#diff-147829161485c14ffc689157f96537744eb64c7cba835d037c51ceeee90d65e2L46-R155) [[2]](diffhunk://#diff-147829161485c14ffc689157f96537744eb64c7cba835d037c51ceeee90d65e2R5-R46) [[3]](diffhunk://#diff-147829161485c14ffc689157f96537744eb64c7cba835d037c51ceeee90d65e2L46-R155)

**Integration with External Tools:**

* The linter can now invoke `clang-tidy` if enabled and available, and will parse and display its warnings alongside built-in checks. The formatter and linter also check for the presence of `clang-format` and `clang-tidy` on the system and handle missing tools gracefully. [[1]](diffhunk://#diff-147829161485c14ffc689157f96537744eb64c7cba835d037c51ceeee90d65e2R232-R282) [[2]](diffhunk://#diff-147829161485c14ffc689157f96537744eb64c7cba835d037c51ceeee90d65e2R312-R336) [[3]](diffhunk://#diff-4ce24d792eb39246af8ea53e0fae09cb593b9990be7082c3998f214b50e86970R101-R165)

**Project Initialization Improvements:**

* The `init` command now creates a default `.clang-format` file in new modules if one does not exist, ensuring consistent formatting out of the box.

These changes significantly improve the usability, flexibility, and robustness of the CLI's formatting and linting workflows, especially for multi-package workspaces.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added workspace support to `fmt` and `lint` commands with `--package` option to target specific members
  * Introduced `[format]` and `[lint]` configuration sections in cmod.toml for customizing directories and exclusions
  * Added `--deny-warnings` flag to lint command for stricter error handling
  * Integrated clang-tidy for enhanced linting capabilities
  * Automatic .clang-format file creation during project initialization
  * Configurable max line length threshold for linting

* **Documentation**
  * Updated CLI reference and configuration guide with new command options and sections

<!-- end of auto-generated comment: release notes by coderabbit.ai -->