### PR TITLE
feat: complete Phase 5 — LSP server, plugin SDK, and ecosystem tooling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **LSP Server** — `textDocument/documentSymbol` for outline/breadcrumb view, `textDocument/references` for finding module importers, `textDocument/codeAction` with quick fixes for missing imports and syntax errors
+- **LSP Build Integration** — `cmod/buildStatus` notification on save, `cmod/dependencies` / `cmod/criticalPath` / `cmod/cacheStatus` custom query methods, diagnostic propagation through module DAG, module graph caching with 30s TTL
+- **Plugin SDK** — argument passing via `key=value` pairs, `min_cmod_version` validation, signed plugin verification wired into `cmod plugin run`, build hook `plugin:` prefix for dispatching hooks to plugins
+- **Plugin Guide** — `docs/guide/plugins.md` with plugin.toml schema, JSON IPC protocol, capability reference, and build hook integration
+- **IDE Integration Guide** — `docs/guide/ide-integration.md` with editor config for Neovim, VS Code, Emacs and custom method reference
+- **Example Plugin** — `examples/plugin/` with hello-plugin demonstrating the JSON IPC protocol
+
 ## [0.1.0] - 2025-01-01
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 **cmod** is a Cargo-inspired, Git-native package and build tool for modern C++20+ modules. It provides dependency resolution, build orchestration, workspace management, and caching — all without a central package registry.
 
-**Status:** Rust implementation (Phase 0-4 complete, Phase 5 in progress). The Cargo workspace compiles and has 750+ passing tests. The 21 RFCs and design documents under `docs/` remain the canonical specification.
+**Status:** Rust implementation (Phase 0-5 complete). The Cargo workspace compiles and has 780+ passing tests. The 21 RFCs and design documents under `docs/` remain the canonical specification.
 
 **Implementation language:** Rust (with LLVM/Clang C++ APIs for build hooks).
 
@@ -254,7 +254,7 @@ Module names follow reverse-domain Git path format: `com.github.user.my_math`.
 | 2 — Scale | **Implemented** | Workspace manager, local cache, cache keys |
 | 3 — Distributed | **Implemented** | Remote cache protocol (HTTP), artifact push/pull, BMI distribution |
 | 4 — Security | **Implemented** | GPG/SSH/Sigstore signing, TOFU trust model, `--locked --verify` modes |
-| 5 — Ecosystem | **In Progress** | LSP server, plugin SDK with sandbox, graph visualization (ASCII/DOT/JSON) |
+| 5 — Ecosystem | **Implemented** | LSP server, plugin SDK with sandbox, graph visualization (ASCII/DOT/JSON) |
 
 ## RFC Tiers
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@
 - **Workspace support** — monorepo management with unified dependency resolution
 - **LLVM/Clang integration** — uses `clang-scan-deps` for automatic module dependency discovery
 - **Security built-in** — hash verification, signature checking, trust-on-first-use (TOFU) model
+- **LSP server** — IDE integration with completion, diagnostics, go-to-definition, references, and code actions
+- **Plugin SDK** — extend cmod with sandboxed plugins using a JSON IPC protocol
 - **30+ CLI commands** — from `init` to `sbom`, covering the full development lifecycle
 
 ## Quick Start
@@ -74,6 +76,7 @@ See the [examples/](examples/) directory for complete working projects:
 | [with-deps](examples/with-deps/) | Git dependencies (fmt + json) |
 | [workspace](examples/workspace/) | Multi-member monorepo |
 | [path-deps](examples/path-deps/) | Local path dependencies |
+| [plugin](examples/plugin/) | Plugin system |
 
 ## Configuration
 
@@ -164,6 +167,7 @@ See `docs/rfc/rfc_unified_cmod_schema.md` for the full schema specification.
 | `cmod publish [--dry-run]` | Publish a release (create a Git tag) |
 | `cmod toolchain show\|check` | Manage the active toolchain |
 | `cmod plugin list\|run` | Manage plugins |
+| `cmod lsp` | Start the LSP server for IDE integration |
 
 ### Global Flags
 
@@ -208,6 +212,7 @@ cmod is implemented as a Rust workspace with focused crates:
 | `cmod-cache` | Content-addressed artifact caching with SHA-256 keys |
 | `cmod-workspace` | Monorepo support, unified dependencies, cross-member builds |
 | `cmod-security` | Hash verification, signature checking, TOFU trust model |
+| `cmod-lsp` | LSP server for IDE integration — completion, diagnostics, references |
 
 Key data flows:
 1. **Resolution:** `cmod.toml` → dependency graph → `cmod.lock`
@@ -239,7 +244,7 @@ Key data flows:
 | 2 — Scale | Done | Workspace manager, local cache, cache keys |
 | 3 — Distributed | Done | Remote cache protocol (HTTP), artifact push/pull, BMI distribution |
 | 4 — Security | Done | GPG/SSH/Sigstore signing, TOFU trust model, `--locked --verify` modes |
-| 5 — Ecosystem | In Progress | LSP server, plugin SDK with sandbox, graph visualization (ASCII/DOT/JSON) |
+| 5 — Ecosystem | Done | LSP server, plugin SDK with sandbox, graph visualization (ASCII/DOT/JSON) |
 
 ## Contributing
 

--- a/crates/cmod-build/src/runner.rs
+++ b/crates/cmod-build/src/runner.rs
@@ -1379,6 +1379,61 @@ pub fn extract_module_name_from_content(content: &str) -> Result<Option<String>,
     Ok(None)
 }
 
+/// Extract import names from source content by scanning for `import` and
+/// `export import` lines.
+///
+/// Returns the imported module (or partition) names, e.g. `["base", ":detail"]`.
+/// Skips comments, the global module fragment, and module declarations.
+pub fn extract_imports_from_content(content: &str) -> Vec<String> {
+    let mut imports = Vec::new();
+    let mut in_block_comment = false;
+
+    for line in content.lines() {
+        let trimmed = line.trim();
+
+        if in_block_comment {
+            if trimmed.contains("*/") {
+                in_block_comment = false;
+            }
+            continue;
+        }
+
+        if trimmed.is_empty() || trimmed.starts_with("//") || trimmed.starts_with('#') {
+            continue;
+        }
+
+        if trimmed.starts_with("/*") {
+            if !trimmed.contains("*/") {
+                in_block_comment = true;
+            }
+            continue;
+        }
+
+        // Handle optional "export" prefix
+        let after_export = trimmed
+            .strip_prefix("export")
+            .map(|s| s.trim())
+            .unwrap_or(trimmed);
+
+        if let Some(after_import) = after_export.strip_prefix("import") {
+            // Skip module declarations that happen to start with "import"
+            // (shouldn't occur in valid C++20, but be safe)
+            let name = after_import.trim().trim_end_matches(';').trim();
+            if !name.is_empty() {
+                imports.push(name.to_string());
+            }
+        }
+    }
+
+    imports
+}
+
+/// Extract imports from a source file on disk.
+pub fn extract_imports(path: &Path) -> Result<Vec<String>, CmodError> {
+    let content = fs::read_to_string(path)?;
+    Ok(extract_imports_from_content(&content))
+}
+
 /// Extract the owning module for a partition declaration.
 ///
 /// For `export module foo:bar;`, returns `Some("foo")`.
@@ -1754,5 +1809,32 @@ mod tests {
         // Pass the same dir twice — should deduplicate
         let sources = discover_sources_multi(&[src.clone(), src], &[]).unwrap();
         assert_eq!(sources.len(), 1);
+    }
+
+    #[test]
+    fn test_extract_imports_from_content() {
+        let content = "\
+export module mylib;
+import base;
+export import utils;
+import :detail;
+// import commented_out;
+";
+        let imports = extract_imports_from_content(content);
+        assert_eq!(imports, vec!["base", "utils", ":detail"]);
+    }
+
+    #[test]
+    fn test_extract_imports_no_semicolon() {
+        let content = "import base\nimport utils;\n";
+        let imports = extract_imports_from_content(content);
+        assert_eq!(imports, vec!["base", "utils"]);
+    }
+
+    #[test]
+    fn test_extract_imports_empty() {
+        let content = "int main() { return 0; }\n";
+        let imports = extract_imports_from_content(content);
+        assert!(imports.is_empty());
     }
 }

--- a/crates/cmod-cli/src/commands/build.rs
+++ b/crates/cmod-cli/src/commands/build.rs
@@ -1008,6 +1008,8 @@ fn print_build_stats(stats: &BuildStats, shell: &Shell, timings: bool) {
 /// Execute a build lifecycle hook if configured.
 ///
 /// Hooks run in the project root directory. A non-zero exit code fails the build.
+/// Hook strings beginning with `plugin:` dispatch to the named plugin instead of
+/// running as a shell command (e.g., `pre-build = "plugin:my-analyzer"`).
 pub fn run_hook(
     config: &Config,
     hook_name: &str,
@@ -1018,6 +1020,15 @@ pub fn run_hook(
         Some(c) => c,
         None => return Ok(()),
     };
+
+    // Dispatch to plugin runner if the hook uses the `plugin:` prefix
+    if let Some(plugin_name) = cmd.strip_prefix("plugin:") {
+        shell.status(
+            "Running",
+            format!("{} hook via plugin: {}", hook_name, plugin_name),
+        );
+        return super::plugin::run_plugin(plugin_name.trim(), &[], shell);
+    }
 
     shell.status("Running", format!("{} hook: {}", hook_name, cmd));
 
@@ -1457,5 +1468,31 @@ mod tests {
         // Should not panic with timings enabled
         print_build_stats(&stats, &shell_normal, true);
         print_build_stats(&stats, &shell_verbose, true);
+    }
+
+    #[test]
+    fn test_run_hook_none_is_noop() {
+        let tmp = TempDir::new().unwrap();
+        std::fs::write(
+            tmp.path().join("cmod.toml"),
+            "[package]\nname = \"test\"\nversion = \"0.1.0\"\n",
+        )
+        .unwrap();
+        let config = Config::load(tmp.path()).unwrap();
+        let shell = Shell::new(cmod_core::shell::Verbosity::Quiet);
+        // None command should be a no-op
+        assert!(run_hook(&config, "pre-build", None, &shell).is_ok());
+    }
+
+    #[test]
+    fn test_run_hook_plugin_prefix_detection() {
+        // Verify that "plugin:" prefix is detected
+        let cmd = "plugin:my-analyzer";
+        assert!(cmd.strip_prefix("plugin:").is_some());
+        assert_eq!(cmd.strip_prefix("plugin:").unwrap(), "my-analyzer");
+
+        // Regular commands should not have the prefix
+        let regular = "echo hello";
+        assert!(regular.strip_prefix("plugin:").is_none());
     }
 }

--- a/crates/cmod-cli/src/commands/plugin.rs
+++ b/crates/cmod-cli/src/commands/plugin.rs
@@ -65,8 +65,25 @@ pub fn list(shell: &Shell) -> Result<(), CmodError> {
     Ok(())
 }
 
+/// Parse plugin arguments from `key=value` pairs into a BTreeMap.
+///
+/// Arguments without `=` are treated as positional: `arg0`, `arg1`, etc.
+fn parse_plugin_args(raw_args: &[String]) -> BTreeMap<String, String> {
+    let mut args = BTreeMap::new();
+    let mut positional_index = 0u32;
+    for arg in raw_args {
+        if let Some((key, value)) = arg.split_once('=') {
+            args.insert(key.to_string(), value.to_string());
+        } else {
+            args.insert(format!("arg{}", positional_index), arg.clone());
+            positional_index += 1;
+        }
+    }
+    args
+}
+
 /// Run `cmod plugin run <name>` — execute a plugin.
-pub fn run_plugin(name: &str, shell: &Shell) -> Result<(), CmodError> {
+pub fn run_plugin(name: &str, raw_args: &[String], shell: &Shell) -> Result<(), CmodError> {
     let cwd = std::env::current_dir()?;
     let config = Config::load(&cwd)?;
 
@@ -84,6 +101,20 @@ pub fn run_plugin(name: &str, shell: &Shell) -> Result<(), CmodError> {
     let sandbox = if plugin.path.join("plugin.toml").exists() {
         match load_plugin_manifest(&plugin.path) {
             Ok(manifest) => {
+                // Check min_cmod_version compatibility
+                if let Some(ref min_ver) = manifest.plugin.min_cmod_version {
+                    let current = semver::Version::parse(env!("CARGO_PKG_VERSION"))
+                        .unwrap_or_else(|_| semver::Version::new(0, 0, 0));
+                    if let Ok(required) = semver::VersionReq::parse(&format!(">={}", min_ver)) {
+                        if !required.matches(&current) {
+                            return Err(CmodError::Other(format!(
+                                "plugin '{}' requires cmod >= {}, but current version is {}",
+                                name, min_ver, current,
+                            )));
+                        }
+                    }
+                }
+
                 let (capabilities, unknown) = parse_capabilities(&manifest.capabilities);
                 if !unknown.is_empty() {
                     shell.warn(format!(
@@ -95,6 +126,38 @@ pub fn run_plugin(name: &str, shell: &Shell) -> Result<(), CmodError> {
 
                 let sandbox =
                     PluginSandbox::new(capabilities, config.root.clone(), manifest.limits.clone());
+
+                // Check signature policy
+                let sig_policy = config
+                    .manifest
+                    .security
+                    .as_ref()
+                    .and_then(|s| s.signature_policy.as_deref())
+                    .unwrap_or("none");
+
+                let is_signed = super::plugin_sandbox::verify_plugin_signature(
+                    &plugin.path,
+                    config.manifest.security.as_ref(),
+                )
+                .unwrap_or(false);
+
+                match sig_policy {
+                    "require" if !is_signed => {
+                        return Err(CmodError::SecurityViolation {
+                            reason: format!(
+                                "plugin '{}' is unsigned but signature_policy = \"require\"",
+                                name,
+                            ),
+                        });
+                    }
+                    "warn" if !is_signed => {
+                        shell.warn(format!(
+                            "plugin '{}' is unsigned (signature_policy = \"warn\")",
+                            name,
+                        ));
+                    }
+                    _ => {}
+                }
 
                 // Verify execute capability
                 sandbox.check_execute()?;
@@ -125,7 +188,7 @@ pub fn run_plugin(name: &str, shell: &Shell) -> Result<(), CmodError> {
     let request = PluginRequest {
         action: "run".to_string(),
         project_root: config.root.to_string_lossy().to_string(),
-        args: BTreeMap::new(),
+        args: parse_plugin_args(raw_args),
     };
 
     let request_json = serde_json::to_string(&request).map_err(|e| CmodError::BuildFailed {
@@ -350,5 +413,41 @@ mod tests {
         };
         let json = serde_json::to_string(&req).unwrap();
         assert!(json.contains("\"action\":\"run\""));
+    }
+
+    #[test]
+    fn test_parse_plugin_args_key_value() {
+        let raw = vec!["greeting=hello".to_string(), "target=world".to_string()];
+        let args = parse_plugin_args(&raw);
+        assert_eq!(args.get("greeting").unwrap(), "hello");
+        assert_eq!(args.get("target").unwrap(), "world");
+        assert_eq!(args.len(), 2);
+    }
+
+    #[test]
+    fn test_parse_plugin_args_positional() {
+        let raw = vec![
+            "hello".to_string(),
+            "key=val".to_string(),
+            "world".to_string(),
+        ];
+        let args = parse_plugin_args(&raw);
+        assert_eq!(args.get("arg0").unwrap(), "hello");
+        assert_eq!(args.get("key").unwrap(), "val");
+        assert_eq!(args.get("arg1").unwrap(), "world");
+        assert_eq!(args.len(), 3);
+    }
+
+    #[test]
+    fn test_plugin_request_serialization_with_args() {
+        let mut args = BTreeMap::new();
+        args.insert("greeting".to_string(), "hello".to_string());
+        let req = PluginRequest {
+            action: "run".to_string(),
+            project_root: "/tmp/test".to_string(),
+            args,
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(json.contains("\"greeting\":\"hello\""));
     }
 }

--- a/crates/cmod-cli/src/commands/plugin_sandbox.rs
+++ b/crates/cmod-cli/src/commands/plugin_sandbox.rs
@@ -591,4 +591,65 @@ max_memory_mb = 256
         assert_eq!(output.len(), big.len());
         assert!(!truncated);
     }
+
+    #[test]
+    fn test_min_cmod_version_satisfied() {
+        // Current version should satisfy a low requirement
+        let current = semver::Version::parse(env!("CARGO_PKG_VERSION")).unwrap();
+        let required = semver::VersionReq::parse(">=0.1.0").unwrap();
+        assert!(required.matches(&current));
+    }
+
+    #[test]
+    fn test_min_cmod_version_too_high() {
+        let current = semver::Version::parse(env!("CARGO_PKG_VERSION")).unwrap();
+        let required = semver::VersionReq::parse(">=999.0.0").unwrap();
+        assert!(!required.matches(&current));
+    }
+
+    #[test]
+    fn test_verify_unsigned_plugin_warn_policy() {
+        // An unsigned plugin should return false (not signed)
+        let tmp = TempDir::new().unwrap();
+        std::fs::write(
+            tmp.path().join("plugin.toml"),
+            "[plugin]\nname = \"test\"\nversion = \"1.0.0\"\n",
+        )
+        .unwrap();
+
+        let security = cmod_core::manifest::Security {
+            signing_key: None,
+            signing_backend: None,
+            verify_checksums: None,
+            trusted_sources: vec![],
+            signature_policy: Some("warn".to_string()),
+            oidc_issuer: None,
+            certificate_identity: None,
+        };
+        let result = verify_plugin_signature(tmp.path(), Some(&security)).unwrap();
+        assert!(!result); // Not signed
+    }
+
+    #[test]
+    fn test_verify_unsigned_plugin_require_policy() {
+        // An unsigned plugin with "require" policy - verify returns false
+        let tmp = TempDir::new().unwrap();
+        std::fs::write(
+            tmp.path().join("plugin.toml"),
+            "[plugin]\nname = \"test\"\nversion = \"1.0.0\"\n",
+        )
+        .unwrap();
+
+        let security = cmod_core::manifest::Security {
+            signing_key: None,
+            signing_backend: None,
+            verify_checksums: None,
+            trusted_sources: vec![],
+            signature_policy: Some("require".to_string()),
+            oidc_issuer: None,
+            certificate_identity: None,
+        };
+        let result = verify_plugin_signature(tmp.path(), Some(&security)).unwrap();
+        assert!(!result); // Not signed, so false — caller should reject
+    }
 }

--- a/crates/cmod-cli/src/commands/plugin_sandbox.rs
+++ b/crates/cmod-cli/src/commands/plugin_sandbox.rs
@@ -607,9 +607,36 @@ max_memory_mb = 256
         assert!(!required.matches(&current));
     }
 
+    /// Mirrors the enforcement logic from `plugin.rs` that interprets
+    /// `verify_plugin_signature` + `Security.signature_policy` together.
+    /// Returns `Ok(warned)` on success (`warned` = true when the policy was
+    /// "warn" and the plugin is unsigned), or `Err` when the policy is
+    /// "require" and the plugin is unsigned.
+    fn enforce_signature_policy(
+        plugin_dir: &Path,
+        security: &cmod_core::manifest::Security,
+    ) -> Result<bool, CmodError> {
+        let sig_policy = security
+            .signature_policy
+            .as_deref()
+            .unwrap_or("none");
+
+        let is_signed =
+            verify_plugin_signature(plugin_dir, Some(security)).unwrap_or(false);
+
+        match sig_policy {
+            "require" if !is_signed => Err(CmodError::SecurityViolation {
+                reason: format!(
+                    "plugin is unsigned but signature_policy = \"require\""
+                ),
+            }),
+            "warn" if !is_signed => Ok(true),  // warned
+            _ => Ok(false),                     // no warning needed
+        }
+    }
+
     #[test]
-    fn test_verify_unsigned_plugin_warn_policy() {
-        // An unsigned plugin should return false (not signed)
+    fn test_unsigned_plugin_warn_policy_succeeds_with_warning() {
         let tmp = TempDir::new().unwrap();
         std::fs::write(
             tmp.path().join("plugin.toml"),
@@ -626,13 +653,19 @@ max_memory_mb = 256
             oidc_issuer: None,
             certificate_identity: None,
         };
-        let result = verify_plugin_signature(tmp.path(), Some(&security)).unwrap();
-        assert!(!result); // Not signed
+
+        // verify_plugin_signature should report unsigned
+        let is_signed = verify_plugin_signature(tmp.path(), Some(&security)).unwrap();
+        assert!(!is_signed);
+
+        // Enforcement: "warn" policy must succeed (non-fatal) but flag the warning
+        let result = enforce_signature_policy(tmp.path(), &security);
+        assert!(result.is_ok(), "warn policy should not reject unsigned plugins");
+        assert!(result.unwrap(), "warn policy should indicate a warning was raised");
     }
 
     #[test]
-    fn test_verify_unsigned_plugin_require_policy() {
-        // An unsigned plugin with "require" policy - verify returns false
+    fn test_unsigned_plugin_require_policy_rejects() {
         let tmp = TempDir::new().unwrap();
         std::fs::write(
             tmp.path().join("plugin.toml"),
@@ -649,7 +682,23 @@ max_memory_mb = 256
             oidc_issuer: None,
             certificate_identity: None,
         };
-        let result = verify_plugin_signature(tmp.path(), Some(&security)).unwrap();
-        assert!(!result); // Not signed, so false — caller should reject
+
+        // verify_plugin_signature should report unsigned
+        let is_signed = verify_plugin_signature(tmp.path(), Some(&security)).unwrap();
+        assert!(!is_signed);
+
+        // Enforcement: "require" policy must reject unsigned plugins
+        let result = enforce_signature_policy(tmp.path(), &security);
+        assert!(result.is_err(), "require policy must reject unsigned plugins");
+        let err = result.unwrap_err();
+        match err {
+            CmodError::SecurityViolation { reason } => {
+                assert!(
+                    reason.contains("signature_policy"),
+                    "error should reference signature_policy: {reason}"
+                );
+            }
+            other => panic!("expected SecurityViolation, got: {other}"),
+        }
     }
 }

--- a/crates/cmod-cli/src/commands/plugin_sandbox.rs
+++ b/crates/cmod-cli/src/commands/plugin_sandbox.rs
@@ -616,22 +616,16 @@ max_memory_mb = 256
         plugin_dir: &Path,
         security: &cmod_core::manifest::Security,
     ) -> Result<bool, CmodError> {
-        let sig_policy = security
-            .signature_policy
-            .as_deref()
-            .unwrap_or("none");
+        let sig_policy = security.signature_policy.as_deref().unwrap_or("none");
 
-        let is_signed =
-            verify_plugin_signature(plugin_dir, Some(security)).unwrap_or(false);
+        let is_signed = verify_plugin_signature(plugin_dir, Some(security)).unwrap_or(false);
 
         match sig_policy {
             "require" if !is_signed => Err(CmodError::SecurityViolation {
-                reason: format!(
-                    "plugin is unsigned but signature_policy = \"require\""
-                ),
+                reason: "plugin is unsigned but signature_policy = \"require\"".to_string(),
             }),
-            "warn" if !is_signed => Ok(true),  // warned
-            _ => Ok(false),                     // no warning needed
+            "warn" if !is_signed => Ok(true), // warned
+            _ => Ok(false),                   // no warning needed
         }
     }
 
@@ -660,8 +654,14 @@ max_memory_mb = 256
 
         // Enforcement: "warn" policy must succeed (non-fatal) but flag the warning
         let result = enforce_signature_policy(tmp.path(), &security);
-        assert!(result.is_ok(), "warn policy should not reject unsigned plugins");
-        assert!(result.unwrap(), "warn policy should indicate a warning was raised");
+        assert!(
+            result.is_ok(),
+            "warn policy should not reject unsigned plugins"
+        );
+        assert!(
+            result.unwrap(),
+            "warn policy should indicate a warning was raised"
+        );
     }
 
     #[test]
@@ -689,7 +689,10 @@ max_memory_mb = 256
 
         // Enforcement: "require" policy must reject unsigned plugins
         let result = enforce_signature_policy(tmp.path(), &security);
-        assert!(result.is_err(), "require policy must reject unsigned plugins");
+        assert!(
+            result.is_err(),
+            "require policy must reject unsigned plugins"
+        );
         let err = result.unwrap_err();
         match err {
             CmodError::SecurityViolation { reason } => {

--- a/crates/cmod-cli/src/main.rs
+++ b/crates/cmod-cli/src/main.rs
@@ -426,6 +426,10 @@ enum PluginAction {
     Run {
         /// Plugin name
         name: String,
+
+        /// Arguments to pass to the plugin (key=value pairs)
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
     },
 }
 
@@ -626,7 +630,7 @@ fn main() {
         Commands::Check => commands::check::run(&shell),
         Commands::Plugin { action } => match action {
             PluginAction::List => commands::plugin::list(&shell),
-            PluginAction::Run { name } => commands::plugin::run_plugin(&name, &shell),
+            PluginAction::Run { name, args } => commands::plugin::run_plugin(&name, &args, &shell),
         },
         Commands::Plan => commands::build::plan(&shell, cli.target.clone()),
         Commands::EmitCmake => commands::build::emit_cmake(&shell),

--- a/crates/cmod-lsp/src/completion.rs
+++ b/crates/cmod-lsp/src/completion.rs
@@ -429,10 +429,7 @@ pub fn find_importers(module_name: &str, root: &std::path::Path) -> Vec<(PathBuf
                     .map(|s| s.trim())
                     .unwrap_or(trimmed);
                 if let Some(after_import) = after_export.strip_prefix("import") {
-                    let name = after_import
-                        .trim()
-                        .trim_end_matches(';')
-                        .trim();
+                    let name = after_import.trim().trim_end_matches(';').trim();
                     if name == module_name {
                         results.push((source.clone(), line_num as u32));
                     }

--- a/crates/cmod-lsp/src/completion.rs
+++ b/crates/cmod-lsp/src/completion.rs
@@ -369,12 +369,76 @@ impl CompletionProvider {
     pub fn find_module_info(&self, module_name: &str) -> Option<&ModuleInfo> {
         self.known_modules.iter().find(|m| m.name == module_name)
     }
+
+    /// Get known modules for external use (e.g., rescan trigger check).
+    pub fn known_modules(&self) -> &[ModuleInfo] {
+        &self.known_modules
+    }
 }
 
 impl Default for CompletionProvider {
     fn default() -> Self {
         Self::new()
     }
+}
+
+/// Find all source files that import `module_name` by scanning on disk.
+///
+/// Returns `(file_path, line_number)` pairs.
+pub fn find_importers(module_name: &str, root: &std::path::Path) -> Vec<(PathBuf, u32)> {
+    let manifest_path = root.join("cmod.toml");
+    let content = match std::fs::read_to_string(&manifest_path) {
+        Ok(c) => c,
+        Err(_) => return Vec::new(),
+    };
+    let manifest = match cmod_core::manifest::Manifest::from_str(&content) {
+        Ok(m) => m,
+        Err(_) => return Vec::new(),
+    };
+
+    let src_dirs: Vec<PathBuf> = manifest
+        .build
+        .as_ref()
+        .map(|b| {
+            if b.sources.is_empty() {
+                vec![root.join("src")]
+            } else {
+                b.sources.iter().map(|s| root.join(s)).collect()
+            }
+        })
+        .unwrap_or_else(|| vec![root.join("src")]);
+    let exclude = manifest
+        .build
+        .as_ref()
+        .map(|b| b.exclude.clone())
+        .unwrap_or_default();
+
+    let sources = match cmod_build::runner::discover_sources_multi(&src_dirs, &exclude) {
+        Ok(s) => s,
+        Err(_) => return Vec::new(),
+    };
+
+    let mut results = Vec::new();
+    for source in &sources {
+        if let Ok(content) = std::fs::read_to_string(source) {
+            for (line_num, line) in content.lines().enumerate() {
+                let trimmed = line.trim();
+                if trimmed.starts_with("import") {
+                    let name = trimmed
+                        .strip_prefix("import")
+                        .unwrap_or("")
+                        .trim()
+                        .trim_end_matches(';')
+                        .trim();
+                    if name == module_name {
+                        results.push((source.clone(), line_num as u32));
+                    }
+                }
+            }
+        }
+    }
+
+    results
 }
 
 /// Convert an LSP UTF-16 code-unit offset into a byte offset within a UTF-8 string.
@@ -476,5 +540,30 @@ mod tests {
         let content = "export module test;\nimport std;\n\n";
         let items = provider.complete(content, 2, 0);
         assert!(!items.is_empty());
+    }
+
+    #[test]
+    fn test_find_importers() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        std::fs::create_dir_all(tmp.path().join("src")).unwrap();
+        std::fs::write(
+            tmp.path().join("cmod.toml"),
+            "[package]\nname = \"test\"\nversion = \"0.1.0\"\n",
+        )
+        .unwrap();
+        std::fs::write(
+            tmp.path().join("src").join("lib.cppm"),
+            "export module mylib;\n",
+        )
+        .unwrap();
+        std::fs::write(
+            tmp.path().join("src").join("user.cppm"),
+            "import mylib;\nint main() {}\n",
+        )
+        .unwrap();
+
+        let importers = find_importers("mylib", tmp.path());
+        assert_eq!(importers.len(), 1);
+        assert_eq!(importers[0].1, 0); // Line 0
     }
 }

--- a/crates/cmod-lsp/src/completion.rs
+++ b/crates/cmod-lsp/src/completion.rs
@@ -423,10 +423,13 @@ pub fn find_importers(module_name: &str, root: &std::path::Path) -> Vec<(PathBuf
         if let Ok(content) = std::fs::read_to_string(source) {
             for (line_num, line) in content.lines().enumerate() {
                 let trimmed = line.trim();
-                if trimmed.starts_with("import") {
-                    let name = trimmed
-                        .strip_prefix("import")
-                        .unwrap_or("")
+                // Handle optional "export" prefix: "export import foo;"
+                let after_export = trimmed
+                    .strip_prefix("export")
+                    .map(|s| s.trim())
+                    .unwrap_or(trimmed);
+                if let Some(after_import) = after_export.strip_prefix("import") {
+                    let name = after_import
                         .trim()
                         .trim_end_matches(';')
                         .trim();

--- a/crates/cmod-lsp/src/diagnostics.rs
+++ b/crates/cmod-lsp/src/diagnostics.rs
@@ -413,6 +413,105 @@ fn make_diagnostic(
     })
 }
 
+/// Propagate diagnostics through the module DAG.
+///
+/// When a module has errors, all modules that depend on it should receive
+/// informational diagnostics noting they may be affected.
+pub fn propagate_diagnostics(
+    broken_file: &Path,
+    root: &Path,
+    graph: &Option<cmod_build::graph::ModuleGraph>,
+) -> std::collections::BTreeMap<PathBuf, Vec<Value>> {
+    let mut result: std::collections::BTreeMap<PathBuf, Vec<Value>> =
+        std::collections::BTreeMap::new();
+
+    // Find the module name for the broken file
+    let broken_module = match cmod_build::runner::extract_module_name(broken_file) {
+        Ok(Some(name)) => name,
+        _ => return result,
+    };
+
+    // Use the provided graph, or build a minimal one
+    let owned_graph;
+    let graph_ref = if let Some(g) = graph {
+        g
+    } else {
+        // Try to build a graph from the project root
+        let manifest_path = root.join("cmod.toml");
+        let content = match std::fs::read_to_string(&manifest_path) {
+            Ok(c) => c,
+            Err(_) => return result,
+        };
+        let manifest = match cmod_core::manifest::Manifest::from_str(&content) {
+            Ok(m) => m,
+            Err(_) => return result,
+        };
+        let src_dirs: Vec<PathBuf> = manifest
+            .build
+            .as_ref()
+            .map(|b| {
+                if b.sources.is_empty() {
+                    vec![root.join("src")]
+                } else {
+                    b.sources.iter().map(|s| root.join(s)).collect()
+                }
+            })
+            .unwrap_or_else(|| vec![root.join("src")]);
+        let exclude = manifest
+            .build
+            .as_ref()
+            .map(|b| b.exclude.clone())
+            .unwrap_or_default();
+
+        let sources = match cmod_build::runner::discover_sources_multi(&src_dirs, &exclude) {
+            Ok(s) => s,
+            Err(_) => return result,
+        };
+
+        let mut g = cmod_build::graph::ModuleGraph::new();
+        for source in &sources {
+            if let Ok(Some(name)) = cmod_build::runner::extract_module_name(source) {
+                let kind = cmod_build::runner::classify_source(source)
+                    .unwrap_or(cmod_core::types::ModuleUnitKind::LegacyUnit);
+                let partition_of = cmod_build::runner::extract_partition_owner(source)
+                    .ok()
+                    .flatten();
+                let node = cmod_build::graph::ModuleNode {
+                    id: source.display().to_string(),
+                    name,
+                    kind,
+                    source: source.clone(),
+                    package: String::new(),
+                    imports: Vec::new(),
+                    partition_of,
+                };
+                g.add_node(node);
+            }
+        }
+        owned_graph = g;
+        &owned_graph
+    };
+
+    // Find all nodes that import the broken module
+    for node in graph_ref.nodes.values() {
+        if node.imports.contains(&broken_module) {
+            let diag = make_diagnostic(
+                0,
+                0,
+                DiagnosticSeverity::Information,
+                &format!(
+                    "Module '{}' has errors; this module may be affected",
+                    broken_module
+                ),
+                "cmod-propagated",
+            );
+            result.entry(node.source.clone()).or_default().push(diag);
+        }
+    }
+
+    result
+}
+
 fn find_error_line(error_msg: &str, _content: &str) -> Option<u32> {
     // Try to extract line number from error message
     for part in error_msg.split_whitespace() {
@@ -565,5 +664,77 @@ mod tests {
         assert_eq!(by_file.len(), 2);
         assert_eq!(by_file["src/main.cpp"].len(), 2);
         assert_eq!(by_file["src/lib.cpp"].len(), 1);
+    }
+
+    #[test]
+    fn test_propagate_diagnostics_no_dependents() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        std::fs::create_dir_all(tmp.path().join("src")).unwrap();
+        std::fs::write(
+            tmp.path().join("cmod.toml"),
+            "[package]\nname = \"test\"\nversion = \"0.1.0\"\n",
+        )
+        .unwrap();
+        let broken = tmp.path().join("src").join("lib.cppm");
+        std::fs::write(&broken, "export module mylib;\n").unwrap();
+
+        // No graph, no dependents → empty
+        let result = propagate_diagnostics(&broken, tmp.path(), &None);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_propagate_diagnostics_with_dependents() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        std::fs::create_dir_all(tmp.path().join("src")).unwrap();
+        std::fs::write(
+            tmp.path().join("cmod.toml"),
+            "[package]\nname = \"test\"\nversion = \"0.1.0\"\n",
+        )
+        .unwrap();
+        let broken = tmp.path().join("src").join("base.cppm");
+        std::fs::write(&broken, "export module base;\n").unwrap();
+
+        let dep1 = tmp.path().join("src").join("dep1.cppm");
+        std::fs::write(&dep1, "export module dep1;\nimport base;\n").unwrap();
+
+        let dep2 = tmp.path().join("src").join("dep2.cppm");
+        std::fs::write(&dep2, "export module dep2;\nimport base;\n").unwrap();
+
+        // Build a graph with imports
+        let mut graph = cmod_build::graph::ModuleGraph::new();
+        graph.add_node(cmod_build::graph::ModuleNode {
+            id: broken.display().to_string(),
+            name: "base".into(),
+            kind: cmod_core::types::ModuleUnitKind::InterfaceUnit,
+            source: broken.clone(),
+            package: "test".into(),
+            imports: vec![],
+            partition_of: None,
+        });
+        graph.add_node(cmod_build::graph::ModuleNode {
+            id: dep1.display().to_string(),
+            name: "dep1".into(),
+            kind: cmod_core::types::ModuleUnitKind::InterfaceUnit,
+            source: dep1.clone(),
+            package: "test".into(),
+            imports: vec!["base".into()],
+            partition_of: None,
+        });
+        graph.add_node(cmod_build::graph::ModuleNode {
+            id: dep2.display().to_string(),
+            name: "dep2".into(),
+            kind: cmod_core::types::ModuleUnitKind::InterfaceUnit,
+            source: dep2.clone(),
+            package: "test".into(),
+            imports: vec!["base".into()],
+            partition_of: None,
+        });
+
+        let result = propagate_diagnostics(&broken, tmp.path(), &Some(graph));
+        // dep1 and dep2 both import "base", so both get propagated diagnostics
+        assert_eq!(result.len(), 2);
+        assert!(result.contains_key(&dep1));
+        assert!(result.contains_key(&dep2));
     }
 }

--- a/crates/cmod-lsp/src/diagnostics.rs
+++ b/crates/cmod-lsp/src/diagnostics.rs
@@ -476,13 +476,15 @@ pub fn propagate_diagnostics(
                 let partition_of = cmod_build::runner::extract_partition_owner(source)
                     .ok()
                     .flatten();
+                let imports = cmod_build::runner::extract_imports(source)
+                    .unwrap_or_default();
                 let node = cmod_build::graph::ModuleNode {
                     id: source.display().to_string(),
                     name,
                     kind,
                     source: source.clone(),
                     package: String::new(),
-                    imports: Vec::new(),
+                    imports,
                     partition_of,
                 };
                 g.add_node(node);

--- a/crates/cmod-lsp/src/diagnostics.rs
+++ b/crates/cmod-lsp/src/diagnostics.rs
@@ -476,8 +476,7 @@ pub fn propagate_diagnostics(
                 let partition_of = cmod_build::runner::extract_partition_owner(source)
                     .ok()
                     .flatten();
-                let imports = cmod_build::runner::extract_imports(source)
-                    .unwrap_or_default();
+                let imports = cmod_build::runner::extract_imports(source).unwrap_or_default();
                 let node = cmod_build::graph::ModuleNode {
                     id: source.display().to_string(),
                     name,

--- a/crates/cmod-lsp/src/server.rs
+++ b/crates/cmod-lsp/src/server.rs
@@ -1082,8 +1082,7 @@ fn build_module_graph_from_root(root: &std::path::Path) -> Option<ModuleGraph> {
             .ok()
             .flatten();
 
-        let imports = cmod_build::runner::extract_imports(source)
-            .unwrap_or_default();
+        let imports = cmod_build::runner::extract_imports(source).unwrap_or_default();
         let node = cmod_build::graph::ModuleNode {
             id: source.display().to_string(),
             name: module_name,

--- a/crates/cmod-lsp/src/server.rs
+++ b/crates/cmod-lsp/src/server.rs
@@ -627,8 +627,13 @@ impl LspServer {
             for (doc_uri, doc_content) in docs.iter() {
                 for (line_num, line_text) in doc_content.lines().enumerate() {
                     let trimmed = line_text.trim();
-                    if trimmed.starts_with("import") && trimmed.contains(module_name) {
-                        let import_name = trimmed
+                    // Handle optional "export" prefix
+                    let after_export = trimmed
+                        .strip_prefix("export")
+                        .map(|s| s.trim())
+                        .unwrap_or(trimmed);
+                    if after_export.starts_with("import") && trimmed.contains(module_name) {
+                        let import_name = after_export
                             .strip_prefix("import")
                             .unwrap_or("")
                             .trim()
@@ -1077,13 +1082,15 @@ fn build_module_graph_from_root(root: &std::path::Path) -> Option<ModuleGraph> {
             .ok()
             .flatten();
 
+        let imports = cmod_build::runner::extract_imports(source)
+            .unwrap_or_default();
         let node = cmod_build::graph::ModuleNode {
             id: source.display().to_string(),
             name: module_name,
             kind,
             source: source.clone(),
             package: pkg_name.clone(),
-            imports: Vec::new(), // simplified — we don't parse imports in LSP graph
+            imports,
             partition_of,
         };
         graph.add_node(node);

--- a/crates/cmod-lsp/src/server.rs
+++ b/crates/cmod-lsp/src/server.rs
@@ -11,10 +11,12 @@ use std::collections::BTreeMap;
 use std::io::{BufRead, Write};
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
+use std::time::Instant;
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+use cmod_build::graph::ModuleGraph;
 use cmod_core::error::CmodError;
 
 use crate::completion::CompletionProvider;
@@ -36,6 +38,10 @@ pub struct LspServer {
     initialized: bool,
     /// Whether shutdown has been requested.
     shutdown_requested: bool,
+    /// Cached module graph.
+    module_graph: Option<ModuleGraph>,
+    /// When the cached graph was last built.
+    graph_timestamp: Option<Instant>,
 }
 
 /// Server capabilities advertised to the client.
@@ -56,6 +62,15 @@ pub struct ServerCapabilities {
     /// Whether go-to-definition is supported.
     #[serde(rename = "definitionProvider")]
     pub definition_provider: bool,
+    /// Whether document symbol (outline) is supported.
+    #[serde(rename = "documentSymbolProvider")]
+    pub document_symbol_provider: bool,
+    /// Whether find references is supported.
+    #[serde(rename = "referencesProvider")]
+    pub references_provider: bool,
+    /// Whether code actions are supported.
+    #[serde(rename = "codeActionProvider")]
+    pub code_action_provider: bool,
 }
 
 /// Completion provider options.
@@ -128,9 +143,14 @@ impl LspServer {
                 }),
                 hover_provider: true,
                 definition_provider: true,
+                document_symbol_provider: true,
+                references_provider: true,
+                code_action_provider: true,
             },
             initialized: false,
             shutdown_requested: false,
+            module_graph: None,
+            graph_timestamp: None,
         }
     }
 
@@ -165,6 +185,7 @@ impl LspServer {
     }
 
     /// Handle a single JSON-RPC message.
+    #[allow(clippy::too_many_lines)]
     pub fn handle_message(&mut self, msg: JsonRpcMessage) -> Option<Vec<JsonRpcMessage>> {
         let method = msg.method.as_deref()?;
         let id = msg.id.clone();
@@ -211,6 +232,33 @@ impl LspServer {
             "textDocument/definition" => {
                 let location = self.handle_definition(msg.params.as_ref());
                 Some(vec![make_response(id, location, None)])
+            }
+            "textDocument/documentSymbol" => {
+                let symbols = self.handle_document_symbol(msg.params.as_ref());
+                let result = serde_json::to_value(symbols).ok()?;
+                Some(vec![make_response(id, Some(result), None)])
+            }
+            "textDocument/references" => {
+                let refs = self.handle_references(msg.params.as_ref());
+                let result = serde_json::to_value(refs).ok()?;
+                Some(vec![make_response(id, Some(result), None)])
+            }
+            "textDocument/codeAction" => {
+                let actions = self.handle_code_action(msg.params.as_ref());
+                let result = serde_json::to_value(actions).ok()?;
+                Some(vec![make_response(id, Some(result), None)])
+            }
+            "cmod/dependencies" => {
+                let result = self.handle_dependencies(msg.params.as_ref());
+                Some(vec![make_response(id, result, None)])
+            }
+            "cmod/criticalPath" => {
+                let result = self.handle_critical_path();
+                Some(vec![make_response(id, result, None)])
+            }
+            "cmod/cacheStatus" => {
+                let result = self.handle_cache_status();
+                Some(vec![make_response(id, result, None)])
             }
             _ => {
                 // Method not found
@@ -298,10 +346,24 @@ impl LspServer {
         None
     }
 
-    fn handle_did_save(&self, params: Option<&Value>) -> Option<Vec<JsonRpcMessage>> {
+    fn handle_did_save(&mut self, params: Option<&Value>) -> Option<Vec<JsonRpcMessage>> {
         let uri = params?.get("textDocument")?.get("uri")?.as_str()?;
 
         let path = uri_to_path(uri);
+
+        // If cmod.toml was saved, refresh completion provider and invalidate graph cache
+        let file_name = path
+            .file_name()
+            .map(|n| n.to_string_lossy().to_string())
+            .unwrap_or_default();
+        if file_name == "cmod.toml" {
+            if let Some(ref root) = self.root {
+                self.completion.set_project_root(root.clone());
+            }
+            self.module_graph = None;
+            self.graph_timestamp = None;
+        }
+
         let mut all_diagnostics = self.diagnostics.diagnose_file(&path);
 
         // Also check for build log diagnostics from the last build
@@ -312,7 +374,6 @@ impl LspServer {
                     let clang_diags = crate::diagnostics::parse_clang_diagnostics(&log_content);
                     let by_file = crate::diagnostics::clang_diagnostics_to_lsp(&clang_diags);
 
-                    // Get the file path relative to root for matching
                     let file_str = path.to_string_lossy();
                     for (diag_file, diags) in &by_file {
                         if file_str.ends_with(diag_file) {
@@ -322,6 +383,8 @@ impl LspServer {
                 }
             }
         }
+
+        let mut messages = Vec::new();
 
         let notification = JsonRpcMessage {
             jsonrpc: "2.0".to_string(),
@@ -334,8 +397,39 @@ impl LspServer {
             result: None,
             error: None,
         };
+        messages.push(notification);
 
-        Some(vec![notification])
+        // Propagate diagnostics through module graph
+        if !all_diagnostics.is_empty() {
+            if let Some(ref root) = self.root.clone() {
+                let propagated =
+                    crate::diagnostics::propagate_diagnostics(&path, root, &self.module_graph);
+                for (dep_path, dep_diags) in propagated {
+                    let dep_uri = format!("file://{}", dep_path.display());
+                    let prop_notification = JsonRpcMessage {
+                        jsonrpc: "2.0".to_string(),
+                        id: None,
+                        method: Some("textDocument/publishDiagnostics".to_string()),
+                        params: Some(serde_json::json!({
+                            "uri": dep_uri,
+                            "diagnostics": dep_diags,
+                        })),
+                        result: None,
+                        error: None,
+                    };
+                    messages.push(prop_notification);
+                }
+            }
+        }
+
+        // Emit cmod/buildStatus notification
+        if let Some(ref root) = self.root {
+            if let Some(status) = build_status_notification(root) {
+                messages.push(status);
+            }
+        }
+
+        Some(messages)
     }
 
     fn handle_completion(&self, params: Option<&Value>) -> Vec<Value> {
@@ -471,6 +565,290 @@ impl LspServer {
 
         None
     }
+
+    /// Handle `textDocument/documentSymbol` — return outline symbols.
+    fn handle_document_symbol(&self, params: Option<&Value>) -> Vec<Value> {
+        let uri = match params
+            .and_then(|p| p.get("textDocument"))
+            .and_then(|d| d.get("uri"))
+            .and_then(|v| v.as_str())
+        {
+            Some(u) => u,
+            None => return Vec::new(),
+        };
+
+        let content = self
+            .documents
+            .lock()
+            .ok()
+            .and_then(|docs| docs.get(uri).cloned())
+            .unwrap_or_default();
+
+        extract_document_symbols(&content)
+    }
+
+    /// Handle `textDocument/references` — find all importers of the module at cursor.
+    fn handle_references(&self, params: Option<&Value>) -> Vec<Value> {
+        let uri = params
+            .and_then(|p| p.get("textDocument"))
+            .and_then(|d| d.get("uri"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+
+        let content = self
+            .documents
+            .lock()
+            .ok()
+            .and_then(|docs| docs.get(uri).cloned())
+            .unwrap_or_default();
+
+        let line = params
+            .and_then(|p| p.get("position"))
+            .and_then(|pos| pos.get("line"))
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0) as usize;
+
+        let character = params
+            .and_then(|p| p.get("position"))
+            .and_then(|pos| pos.get("character"))
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0) as usize;
+
+        let word = match extract_word_at(&content, line, character) {
+            Some(w) => w,
+            None => return Vec::new(),
+        };
+
+        let module_name = word.trim_end_matches(';');
+
+        // Search open documents for imports of this module
+        let mut refs = Vec::new();
+        if let Ok(docs) = self.documents.lock() {
+            for (doc_uri, doc_content) in docs.iter() {
+                for (line_num, line_text) in doc_content.lines().enumerate() {
+                    let trimmed = line_text.trim();
+                    if trimmed.starts_with("import") && trimmed.contains(module_name) {
+                        let import_name = trimmed
+                            .strip_prefix("import")
+                            .unwrap_or("")
+                            .trim()
+                            .trim_end_matches(';')
+                            .trim();
+                        if import_name == module_name {
+                            refs.push(serde_json::json!({
+                                "uri": doc_uri,
+                                "range": {
+                                    "start": { "line": line_num, "character": 0 },
+                                    "end": { "line": line_num, "character": line_text.len() },
+                                }
+                            }));
+                        }
+                    }
+                }
+            }
+        }
+
+        // Also search source files on disk
+        if let Some(ref root) = self.root {
+            let importers = crate::completion::find_importers(module_name, root);
+            for (file_path, file_line) in importers {
+                let file_uri = format!("file://{}", file_path.display());
+                // Skip if already found in open documents
+                if refs.iter().any(|r| r["uri"] == file_uri) {
+                    continue;
+                }
+                refs.push(serde_json::json!({
+                    "uri": file_uri,
+                    "range": {
+                        "start": { "line": file_line, "character": 0 },
+                        "end": { "line": file_line, "character": 1 },
+                    }
+                }));
+            }
+        }
+
+        refs
+    }
+
+    /// Handle `textDocument/codeAction` — return quick-fix code actions.
+    fn handle_code_action(&self, params: Option<&Value>) -> Vec<Value> {
+        let uri = match params
+            .and_then(|p| p.get("textDocument"))
+            .and_then(|d| d.get("uri"))
+            .and_then(|v| v.as_str())
+        {
+            Some(u) => u,
+            None => return Vec::new(),
+        };
+
+        let diagnostics = params
+            .and_then(|p| p.get("context"))
+            .and_then(|c| c.get("diagnostics"))
+            .and_then(|d| d.as_array())
+            .cloned()
+            .unwrap_or_default();
+
+        let mut actions = Vec::new();
+
+        for diag in &diagnostics {
+            let code = diag.get("code").and_then(|c| c.as_str()).unwrap_or("");
+            let message = diag.get("message").and_then(|m| m.as_str()).unwrap_or("");
+
+            match code {
+                "cmod-unknown-import" => {
+                    // Extract module name from diagnostic message
+                    if let Some(module_name) = message
+                        .strip_prefix("module '")
+                        .and_then(|s| s.split('\'').next())
+                    {
+                        actions.push(serde_json::json!({
+                            "title": format!("Add '{}' to dependencies", module_name),
+                            "kind": "quickfix",
+                            "diagnostics": [diag],
+                            "command": {
+                                "title": format!("cmod add {}", module_name),
+                                "command": "cmod.add",
+                                "arguments": [module_name],
+                            }
+                        }));
+                    }
+                }
+                "cmod-syntax" => {
+                    if message.contains("semicolon") {
+                        let range = diag.get("range").cloned().unwrap_or(serde_json::json!({
+                            "start": { "line": 0, "character": 0 },
+                            "end": { "line": 0, "character": 0 },
+                        }));
+                        let end_line = range
+                            .get("end")
+                            .and_then(|e| e.get("line"))
+                            .and_then(|l| l.as_u64())
+                            .unwrap_or(0);
+                        // Get the line content to find where to insert semicolon
+                        let insert_char = self
+                            .documents
+                            .lock()
+                            .ok()
+                            .and_then(|docs| docs.get(uri).cloned())
+                            .and_then(|content| {
+                                content
+                                    .lines()
+                                    .nth(end_line as usize)
+                                    .map(|l| l.trim_end().len())
+                            })
+                            .unwrap_or(0);
+
+                        actions.push(serde_json::json!({
+                            "title": "Add missing semicolon",
+                            "kind": "quickfix",
+                            "diagnostics": [diag],
+                            "edit": {
+                                "changes": {
+                                    uri: [{
+                                        "range": {
+                                            "start": { "line": end_line, "character": insert_char },
+                                            "end": { "line": end_line, "character": insert_char },
+                                        },
+                                        "newText": ";",
+                                    }]
+                                }
+                            }
+                        }));
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        actions
+    }
+
+    /// Handle `cmod/dependencies` — return deps/dependents for a module.
+    fn handle_dependencies(&mut self, params: Option<&Value>) -> Option<Value> {
+        let module_name = params?.get("module")?.as_str()?;
+        let graph = self.ensure_graph()?;
+
+        let mut dependencies = Vec::new();
+        let mut dependents = Vec::new();
+
+        if let Some(node) = graph.nodes.values().find(|n| n.name == module_name) {
+            dependencies = node.imports.clone();
+        }
+
+        // Find dependents: nodes that import this module
+        for node in graph.nodes.values() {
+            if node.imports.contains(&module_name.to_string()) {
+                dependents.push(node.name.clone());
+            }
+        }
+
+        Some(serde_json::json!({
+            "dependencies": dependencies,
+            "dependents": dependents,
+        }))
+    }
+
+    /// Handle `cmod/criticalPath` — return the critical path.
+    fn handle_critical_path(&mut self) -> Option<Value> {
+        let root = self.root.clone()?;
+        let graph = self.ensure_graph()?;
+
+        // Load timings from build state if available
+        let timings_path = root.join("build").join("timings.json");
+        let timings: BTreeMap<String, u64> = std::fs::read_to_string(&timings_path)
+            .ok()
+            .and_then(|s| serde_json::from_str(&s).ok())
+            .unwrap_or_default();
+
+        let path = graph.critical_path(&timings);
+        Some(serde_json::json!({ "criticalPath": path }))
+    }
+
+    /// Handle `cmod/cacheStatus` — return cache info.
+    fn handle_cache_status(&self) -> Option<Value> {
+        let root = self.root.as_ref()?;
+        let cache_dir = root.join("build").join("cache");
+
+        let (entries, total_size) = if cache_dir.exists() {
+            let mut count = 0u64;
+            let mut size = 0u64;
+            if let Ok(rd) = std::fs::read_dir(&cache_dir) {
+                for entry in rd.flatten() {
+                    if let Ok(meta) = entry.metadata() {
+                        count += 1;
+                        size += meta.len();
+                    }
+                }
+            }
+            (count, size)
+        } else {
+            (0, 0)
+        };
+
+        Some(serde_json::json!({
+            "entries": entries,
+            "totalSizeBytes": total_size,
+        }))
+    }
+
+    /// Get (or rebuild) the cached module graph. Returns None if no project root.
+    fn ensure_graph(&mut self) -> Option<&ModuleGraph> {
+        let stale = match self.graph_timestamp {
+            Some(ts) => ts.elapsed().as_secs() > 30,
+            None => true,
+        };
+
+        if stale || self.module_graph.is_none() {
+            if let Some(ref root) = self.root.clone() {
+                if let Some(graph) = build_module_graph_from_root(root) {
+                    self.module_graph = Some(graph);
+                    self.graph_timestamp = Some(Instant::now());
+                }
+            }
+        }
+
+        self.module_graph.as_ref()
+    }
 }
 
 impl Default for LspServer {
@@ -544,6 +922,256 @@ fn make_response(
 fn uri_to_path(uri: &str) -> PathBuf {
     let path_str = uri.strip_prefix("file://").unwrap_or(uri);
     PathBuf::from(path_str)
+}
+
+/// Extract document symbols (outline) from C++ module source content.
+fn extract_document_symbols(content: &str) -> Vec<Value> {
+    let mut symbols = Vec::new();
+
+    for (line_num, line) in content.lines().enumerate() {
+        let trimmed = line.trim();
+        let line_u32 = line_num as u32;
+
+        // export module <name>;
+        if let Some(rest) = trimmed.strip_prefix("export module ") {
+            let name = rest.trim_end_matches(';').trim();
+            if !name.is_empty() {
+                symbols.push(make_symbol(name, 2, line_u32)); // 2 = Module
+            }
+            continue;
+        }
+
+        // import <name>;
+        if let Some(rest) = trimmed.strip_prefix("import ") {
+            let name = rest.trim_end_matches(';').trim();
+            if !name.is_empty() && !name.starts_with('<') && !name.starts_with('"') {
+                symbols.push(make_symbol(name, 4, line_u32)); // 4 = Package
+            }
+            continue;
+        }
+
+        // export class|struct <name>
+        if let Some(rest) = trimmed
+            .strip_prefix("export class ")
+            .or_else(|| trimmed.strip_prefix("export struct "))
+        {
+            let name = rest
+                .split(|c: char| !c.is_alphanumeric() && c != '_')
+                .next()
+                .unwrap_or("");
+            if !name.is_empty() {
+                symbols.push(make_symbol(name, 5, line_u32)); // 5 = Class
+            }
+            continue;
+        }
+
+        // export namespace <name>
+        if let Some(rest) = trimmed.strip_prefix("export namespace ") {
+            let name = rest
+                .split(|c: char| !c.is_alphanumeric() && c != '_')
+                .next()
+                .unwrap_or("");
+            if !name.is_empty() {
+                symbols.push(make_symbol(name, 3, line_u32)); // 3 = Namespace
+            }
+            continue;
+        }
+
+        // export enum <name>
+        if let Some(rest) = trimmed.strip_prefix("export enum ") {
+            let name = rest
+                .split(|c: char| !c.is_alphanumeric() && c != '_')
+                .next()
+                .unwrap_or("");
+            if !name.is_empty() {
+                symbols.push(make_symbol(name, 10, line_u32)); // 10 = Enum
+            }
+            continue;
+        }
+
+        // export [qualifiers] <return_type> <name>(  — function
+        if trimmed.starts_with("export ") && trimmed.contains('(') {
+            // Skip if already matched above
+            if !trimmed.contains("module ")
+                && !trimmed.contains("class ")
+                && !trimmed.contains("struct ")
+                && !trimmed.contains("namespace ")
+                && !trimmed.contains("enum ")
+                && !trimmed.contains("import ")
+            {
+                // Find function name: the token before '('
+                if let Some(paren_idx) = trimmed.find('(') {
+                    let before_paren = &trimmed[..paren_idx].trim_end();
+                    let func_name = before_paren
+                        .rsplit(|c: char| !c.is_alphanumeric() && c != '_')
+                        .next()
+                        .unwrap_or("");
+                    if !func_name.is_empty() {
+                        symbols.push(make_symbol(func_name, 12, line_u32)); // 12 = Function
+                    }
+                }
+            }
+        }
+    }
+
+    symbols
+}
+
+fn make_symbol(name: &str, kind: u8, line: u32) -> Value {
+    serde_json::json!({
+        "name": name,
+        "kind": kind,
+        "range": {
+            "start": { "line": line, "character": 0 },
+            "end": { "line": line, "character": 0 },
+        },
+        "selectionRange": {
+            "start": { "line": line, "character": 0 },
+            "end": { "line": line, "character": 0 },
+        },
+    })
+}
+
+/// Build a `ModuleGraph` from the project root by scanning sources.
+fn build_module_graph_from_root(root: &std::path::Path) -> Option<ModuleGraph> {
+    let manifest_path = root.join("cmod.toml");
+    let content = std::fs::read_to_string(&manifest_path).ok()?;
+    let manifest = cmod_core::manifest::Manifest::from_str(&content).ok()?;
+
+    let pkg_name = &manifest.package.name;
+
+    let src_dirs: Vec<PathBuf> = manifest
+        .build
+        .as_ref()
+        .map(|b| {
+            if b.sources.is_empty() {
+                vec![root.join("src")]
+            } else {
+                b.sources.iter().map(|s| root.join(s)).collect()
+            }
+        })
+        .unwrap_or_else(|| vec![root.join("src")]);
+    let exclude = manifest
+        .build
+        .as_ref()
+        .map(|b| b.exclude.clone())
+        .unwrap_or_default();
+
+    let sources = cmod_build::runner::discover_sources_multi(&src_dirs, &exclude).ok()?;
+
+    let mut graph = ModuleGraph::new();
+    for source in &sources {
+        let kind = cmod_build::runner::classify_source(source)
+            .unwrap_or(cmod_core::types::ModuleUnitKind::LegacyUnit);
+        let module_name = cmod_build::runner::extract_module_name(source)
+            .ok()
+            .flatten()
+            .unwrap_or_else(|| {
+                source
+                    .file_stem()
+                    .and_then(|s| s.to_str())
+                    .unwrap_or("unknown")
+                    .to_string()
+            });
+        let partition_of = cmod_build::runner::extract_partition_owner(source)
+            .ok()
+            .flatten();
+
+        let node = cmod_build::graph::ModuleNode {
+            id: source.display().to_string(),
+            name: module_name,
+            kind,
+            source: source.clone(),
+            package: pkg_name.clone(),
+            imports: Vec::new(), // simplified — we don't parse imports in LSP graph
+            partition_of,
+        };
+        graph.add_node(node);
+    }
+
+    Some(graph)
+}
+
+/// Build the `cmod/buildStatus` notification from build state on disk.
+fn build_status_notification(root: &std::path::Path) -> Option<JsonRpcMessage> {
+    let build_dir = root.join("build");
+    if !build_dir.exists() {
+        return None;
+    }
+
+    // Try to load build state JSON
+    let state_path = build_dir.join("build_state.json");
+    let build_state: Option<BTreeMap<String, Value>> = std::fs::read_to_string(&state_path)
+        .ok()
+        .and_then(|s| serde_json::from_str(&s).ok());
+
+    let mut modules = Vec::new();
+    let (mut total, mut up_to_date, mut needs_rebuild, mut never_built) = (0u32, 0u32, 0u32, 0u32);
+
+    // Scan source files to enumerate modules
+    let manifest_path = root.join("cmod.toml");
+    if let Ok(content) = std::fs::read_to_string(&manifest_path) {
+        if let Ok(manifest) = cmod_core::manifest::Manifest::from_str(&content) {
+            let src_dirs: Vec<PathBuf> = manifest
+                .build
+                .as_ref()
+                .map(|b| {
+                    if b.sources.is_empty() {
+                        vec![root.join("src")]
+                    } else {
+                        b.sources.iter().map(|s| root.join(s)).collect()
+                    }
+                })
+                .unwrap_or_else(|| vec![root.join("src")]);
+            let exclude = manifest
+                .build
+                .as_ref()
+                .map(|b| b.exclude.clone())
+                .unwrap_or_default();
+
+            if let Ok(sources) = cmod_build::runner::discover_sources_multi(&src_dirs, &exclude) {
+                for source in &sources {
+                    if let Ok(Some(name)) = cmod_build::runner::extract_module_name(source) {
+                        total += 1;
+                        let status = if let Some(ref state) = build_state {
+                            if state.contains_key(&name) {
+                                up_to_date += 1;
+                                "up-to-date"
+                            } else {
+                                needs_rebuild += 1;
+                                "needs-rebuild"
+                            }
+                        } else {
+                            never_built += 1;
+                            "never-built"
+                        };
+
+                        modules.push(serde_json::json!({
+                            "name": name,
+                            "status": status,
+                        }));
+                    }
+                }
+            }
+        }
+    }
+
+    Some(JsonRpcMessage {
+        jsonrpc: "2.0".to_string(),
+        id: None,
+        method: Some("cmod/buildStatus".to_string()),
+        params: Some(serde_json::json!({
+            "modules": modules,
+            "summary": {
+                "total": total,
+                "upToDate": up_to_date,
+                "needsRebuild": needs_rebuild,
+                "neverBuilt": never_built,
+            }
+        })),
+        result: None,
+        error: None,
+    })
 }
 
 fn extract_word_at(content: &str, line: usize, character: usize) -> Option<String> {
@@ -727,5 +1355,359 @@ mod tests {
 
         let docs = server.documents.lock().unwrap();
         assert!(docs.contains_key("file:///tmp/test.cpp"));
+    }
+
+    // --- 5B-1: Document Symbol tests ---
+
+    #[test]
+    fn test_document_symbol_empty_file() {
+        let symbols = extract_document_symbols("");
+        assert!(symbols.is_empty());
+    }
+
+    #[test]
+    fn test_document_symbol_module_and_imports() {
+        let content = "export module mylib;\nimport std;\nimport fmt;\n";
+        let symbols = extract_document_symbols(content);
+        assert_eq!(symbols.len(), 3);
+        // Module declaration
+        assert_eq!(symbols[0]["name"], "mylib");
+        assert_eq!(symbols[0]["kind"], 2); // Module
+                                           // Imports
+        assert_eq!(symbols[1]["name"], "std");
+        assert_eq!(symbols[1]["kind"], 4); // Package
+        assert_eq!(symbols[2]["name"], "fmt");
+        assert_eq!(symbols[2]["kind"], 4);
+    }
+
+    #[test]
+    fn test_document_symbol_exports() {
+        let content = concat!(
+            "export module test;\n",
+            "export class Widget {\n};\n",
+            "export namespace utils {\n};\n",
+            "export enum Color {\n};\n",
+            "export int compute(int x) {\n}\n",
+        );
+        let symbols = extract_document_symbols(content);
+        let names: Vec<&str> = symbols
+            .iter()
+            .filter_map(|s| s.get("name").and_then(|n| n.as_str()))
+            .collect();
+        assert!(names.contains(&"test"));
+        assert!(names.contains(&"Widget"));
+        assert!(names.contains(&"utils"));
+        assert!(names.contains(&"Color"));
+        assert!(names.contains(&"compute"));
+    }
+
+    // --- 5B-2: References tests ---
+
+    #[test]
+    fn test_references_no_refs() {
+        let mut server = LspServer::new();
+        let open_params = serde_json::json!({
+            "textDocument": {
+                "uri": "file:///tmp/a.cppm",
+                "text": "export module mymod;\n"
+            }
+        });
+        server.handle_did_open(Some(&open_params));
+
+        let msg = JsonRpcMessage {
+            jsonrpc: "2.0".into(),
+            id: Some(Value::Number(2.into())),
+            method: Some("textDocument/references".into()),
+            params: Some(serde_json::json!({
+                "textDocument": { "uri": "file:///tmp/a.cppm" },
+                "position": { "line": 0, "character": 14 },
+                "context": { "includeDeclaration": true }
+            })),
+            result: None,
+            error: None,
+        };
+
+        let responses = server.handle_message(msg).unwrap();
+        let refs = responses[0].result.as_ref().unwrap().as_array().unwrap();
+        // No other files import "mymod"
+        assert!(refs.is_empty());
+    }
+
+    #[test]
+    fn test_references_in_open_docs() {
+        let mut server = LspServer::new();
+        // Open module file
+        server.handle_did_open(Some(&serde_json::json!({
+            "textDocument": {
+                "uri": "file:///tmp/lib.cppm",
+                "text": "export module mylib;\n"
+            }
+        })));
+        // Open a file that imports it
+        server.handle_did_open(Some(&serde_json::json!({
+            "textDocument": {
+                "uri": "file:///tmp/main.cppm",
+                "text": "import mylib;\nint main() {}\n"
+            }
+        })));
+
+        let msg = JsonRpcMessage {
+            jsonrpc: "2.0".into(),
+            id: Some(Value::Number(3.into())),
+            method: Some("textDocument/references".into()),
+            params: Some(serde_json::json!({
+                "textDocument": { "uri": "file:///tmp/lib.cppm" },
+                "position": { "line": 0, "character": 14 },
+                "context": { "includeDeclaration": true }
+            })),
+            result: None,
+            error: None,
+        };
+
+        let responses = server.handle_message(msg).unwrap();
+        let refs = responses[0].result.as_ref().unwrap().as_array().unwrap();
+        assert_eq!(refs.len(), 1);
+        assert_eq!(refs[0]["uri"], "file:///tmp/main.cppm");
+    }
+
+    #[test]
+    fn test_references_on_module_declaration() {
+        let mut server = LspServer::new();
+        server.handle_did_open(Some(&serde_json::json!({
+            "textDocument": {
+                "uri": "file:///tmp/mod.cppm",
+                "text": "export module mymod;\nexport int foo() { return 1; }\n"
+            }
+        })));
+        server.handle_did_open(Some(&serde_json::json!({
+            "textDocument": {
+                "uri": "file:///tmp/user.cppm",
+                "text": "import mymod;\nint x = foo();\n"
+            }
+        })));
+
+        let msg = JsonRpcMessage {
+            jsonrpc: "2.0".into(),
+            id: Some(Value::Number(4.into())),
+            method: Some("textDocument/references".into()),
+            params: Some(serde_json::json!({
+                "textDocument": { "uri": "file:///tmp/mod.cppm" },
+                "position": { "line": 0, "character": 14 },
+                "context": { "includeDeclaration": true }
+            })),
+            result: None,
+            error: None,
+        };
+
+        let responses = server.handle_message(msg).unwrap();
+        let refs = responses[0].result.as_ref().unwrap().as_array().unwrap();
+        assert_eq!(refs.len(), 1);
+    }
+
+    // --- 5C-1: Build status tests ---
+
+    #[test]
+    fn test_build_status_no_build_dir() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        // No build/ dir → None
+        let result = build_status_notification(tmp.path());
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_build_status_with_build_dir() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        std::fs::create_dir_all(tmp.path().join("build")).unwrap();
+        std::fs::create_dir_all(tmp.path().join("src")).unwrap();
+        std::fs::write(
+            tmp.path().join("cmod.toml"),
+            "[package]\nname = \"test\"\nversion = \"0.1.0\"\n",
+        )
+        .unwrap();
+        std::fs::write(
+            tmp.path().join("src").join("lib.cppm"),
+            "export module test;\n",
+        )
+        .unwrap();
+
+        let result = build_status_notification(tmp.path());
+        assert!(result.is_some());
+        let msg = result.unwrap();
+        assert_eq!(msg.method.as_deref(), Some("cmod/buildStatus"));
+        let params = msg.params.unwrap();
+        let summary = &params["summary"];
+        assert_eq!(summary["total"], 1);
+        assert_eq!(summary["neverBuilt"], 1);
+    }
+
+    // --- 5C-2: Graph query tests ---
+
+    #[test]
+    fn test_handle_dependencies_empty() {
+        let mut server = LspServer::new();
+        // No root set, so graph won't build
+        let result = server.handle_dependencies(Some(&serde_json::json!({
+            "module": "nonexistent"
+        })));
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_handle_critical_path_no_root() {
+        let mut server = LspServer::new();
+        let result = server.handle_critical_path();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_handle_cache_status_no_root() {
+        let server = LspServer::new();
+        let result = server.handle_cache_status();
+        assert!(result.is_none());
+    }
+
+    // --- 5C-4: Graph caching tests ---
+
+    #[test]
+    fn test_graph_caching_returns_same() {
+        let mut server = LspServer::new();
+        let tmp = tempfile::TempDir::new().unwrap();
+        std::fs::create_dir_all(tmp.path().join("src")).unwrap();
+        std::fs::write(
+            tmp.path().join("cmod.toml"),
+            "[package]\nname = \"test\"\nversion = \"0.1.0\"\n",
+        )
+        .unwrap();
+        std::fs::write(
+            tmp.path().join("src").join("lib.cppm"),
+            "export module test;\n",
+        )
+        .unwrap();
+
+        server.root = Some(tmp.path().to_path_buf());
+
+        // First call builds the graph
+        let graph1 = server.ensure_graph();
+        assert!(graph1.is_some());
+
+        // Immediate re-request should use cached graph (timestamp < 30s)
+        assert!(server.graph_timestamp.is_some());
+        let graph2 = server.ensure_graph();
+        assert!(graph2.is_some());
+    }
+
+    // --- 5D-1: Code Action tests ---
+
+    #[test]
+    fn test_code_action_no_diagnostics() {
+        let server = LspServer::new();
+        let params = serde_json::json!({
+            "textDocument": { "uri": "file:///tmp/test.cppm" },
+            "range": {
+                "start": { "line": 0, "character": 0 },
+                "end": { "line": 0, "character": 0 },
+            },
+            "context": { "diagnostics": [] }
+        });
+
+        let actions = server.handle_code_action(Some(&params));
+        assert!(actions.is_empty());
+    }
+
+    #[test]
+    fn test_code_action_unknown_import() {
+        let server = LspServer::new();
+        let params = serde_json::json!({
+            "textDocument": { "uri": "file:///tmp/test.cppm" },
+            "range": {
+                "start": { "line": 1, "character": 0 },
+                "end": { "line": 1, "character": 1 },
+            },
+            "context": {
+                "diagnostics": [{
+                    "range": {
+                        "start": { "line": 1, "character": 0 },
+                        "end": { "line": 1, "character": 1 },
+                    },
+                    "severity": 2,
+                    "code": "cmod-unknown-import",
+                    "message": "module 'github.fmtlib.fmt' not found in dependencies; add with `cmod add`",
+                }]
+            }
+        });
+
+        let actions = server.handle_code_action(Some(&params));
+        assert_eq!(actions.len(), 1);
+        assert!(actions[0]["title"]
+            .as_str()
+            .unwrap()
+            .contains("github.fmtlib.fmt"));
+    }
+
+    #[test]
+    fn test_code_action_missing_semicolon() {
+        let server = LspServer::new();
+        server.handle_did_open(Some(&serde_json::json!({
+            "textDocument": {
+                "uri": "file:///tmp/fix.cppm",
+                "text": "export module test\n"
+            }
+        })));
+
+        let params = serde_json::json!({
+            "textDocument": { "uri": "file:///tmp/fix.cppm" },
+            "range": {
+                "start": { "line": 0, "character": 0 },
+                "end": { "line": 0, "character": 1 },
+            },
+            "context": {
+                "diagnostics": [{
+                    "range": {
+                        "start": { "line": 0, "character": 0 },
+                        "end": { "line": 0, "character": 1 },
+                    },
+                    "severity": 1,
+                    "code": "cmod-syntax",
+                    "message": "module declaration should end with semicolon",
+                }]
+            }
+        });
+
+        let actions = server.handle_code_action(Some(&params));
+        assert_eq!(actions.len(), 1);
+        assert_eq!(actions[0]["title"], "Add missing semicolon");
+    }
+
+    // --- 5D-2: Completion refresh on manifest save ---
+
+    #[test]
+    fn test_manifest_save_triggers_rescan() {
+        let mut server = LspServer::new();
+        let tmp = tempfile::TempDir::new().unwrap();
+        std::fs::create_dir_all(tmp.path().join("src")).unwrap();
+        std::fs::write(
+            tmp.path().join("cmod.toml"),
+            "[package]\nname = \"test\"\nversion = \"0.1.0\"\n",
+        )
+        .unwrap();
+
+        server.root = Some(tmp.path().to_path_buf());
+        server.completion.set_project_root(tmp.path().to_path_buf());
+
+        // Set a cached graph
+        server.module_graph = Some(ModuleGraph::new());
+        server.graph_timestamp = Some(Instant::now());
+
+        // Simulate saving cmod.toml
+        let save_params = serde_json::json!({
+            "textDocument": {
+                "uri": format!("file://{}/cmod.toml", tmp.path().display()),
+            }
+        });
+        server.handle_did_save(Some(&save_params));
+
+        // Graph cache should be invalidated
+        assert!(server.module_graph.is_none());
+        assert!(server.graph_timestamp.is_none());
     }
 }

--- a/docs/guide/cli-reference.md
+++ b/docs/guide/cli-reference.md
@@ -624,11 +624,20 @@ cmod plugin list
 
 ### `cmod plugin run`
 
-Run a plugin by name.
+Run a plugin by name, optionally passing arguments.
 
 ```
-cmod plugin run <NAME>
+cmod plugin run <NAME> [-- key=value ...]
 ```
+
+Arguments after `--` are passed to the plugin as key-value pairs in the JSON request.
+Positional arguments (without `=`) are mapped to `arg0`, `arg1`, etc.
+
+```bash
+cmod plugin run my-analyzer -- greeting=hello target=world
+```
+
+See the [Plugin Development Guide](plugins.md) for authoring plugins.
 
 ---
 
@@ -636,8 +645,12 @@ cmod plugin run <NAME>
 
 ### `cmod lsp`
 
-Start the LSP server for IDE integration.
+Start the LSP server for IDE integration. Communicates via JSON-RPC over stdin/stdout.
 
 ```
 cmod lsp
 ```
+
+Supported LSP features: completion, hover, go-to-definition, document symbols, find references, diagnostics, code actions. Also supports custom `cmod/buildStatus`, `cmod/dependencies`, `cmod/criticalPath`, and `cmod/cacheStatus` methods.
+
+See the [IDE Integration Guide](ide-integration.md) for editor configuration.

--- a/docs/guide/cli-reference.md
+++ b/docs/guide/cli-reference.md
@@ -626,7 +626,7 @@ cmod plugin list
 
 Run a plugin by name, optionally passing arguments.
 
-```
+```bash
 cmod plugin run <NAME> [-- key=value ...]
 ```
 
@@ -647,7 +647,7 @@ See the [Plugin Development Guide](plugins.md) for authoring plugins.
 
 Start the LSP server for IDE integration. Communicates via JSON-RPC over stdin/stdout.
 
-```
+```bash
 cmod lsp
 ```
 

--- a/docs/guide/ide-integration.md
+++ b/docs/guide/ide-integration.md
@@ -52,25 +52,31 @@ Sent after `textDocument/didSave`. Payload:
 
 ### `cmod/dependencies` Request
 
-```json
-// Request params:
-{ "module": "mylib" }
+Request params:
 
-// Response:
+```json
+{ "module": "mylib" }
+```
+
+Response:
+
+```json
 { "dependencies": ["base"], "dependents": ["app"] }
 ```
 
 ### `cmod/criticalPath` Request
 
+Response:
+
 ```json
-// Response:
 { "criticalPath": ["base", "mylib", "app"] }
 ```
 
 ### `cmod/cacheStatus` Request
 
+Response:
+
 ```json
-// Response:
 { "entries": 42, "totalSizeBytes": 10485760 }
 ```
 

--- a/docs/guide/ide-integration.md
+++ b/docs/guide/ide-integration.md
@@ -1,0 +1,122 @@
+# IDE Integration Guide
+
+cmod includes a built-in Language Server Protocol (LSP) server for IDE support.
+
+## Starting the LSP Server
+
+```bash
+cmod lsp
+```
+
+The server communicates via JSON-RPC over stdin/stdout, following the LSP specification.
+
+## Supported Features
+
+| Feature | LSP Method | Description |
+|---|---|---|
+| Completion | `textDocument/completion` | Module names, partitions, C++ keywords |
+| Hover | `textDocument/hover` | Module info, version, description |
+| Go to Definition | `textDocument/definition` | Jump to module interface file |
+| Document Symbols | `textDocument/documentSymbol` | Outline view (modules, classes, functions) |
+| Find References | `textDocument/references` | Find all importers of a module |
+| Diagnostics | `textDocument/publishDiagnostics` | Import errors, manifest validation, build errors |
+| Code Actions | `textDocument/codeAction` | Quick fixes for missing imports, syntax errors |
+
+## Custom cmod Methods
+
+| Method | Direction | Description |
+|---|---|---|
+| `cmod/buildStatus` | Server → Client | Module build status after save |
+| `cmod/dependencies` | Client → Server | Query module dependencies/dependents |
+| `cmod/criticalPath` | Client → Server | Get the critical compilation path |
+| `cmod/cacheStatus` | Client → Server | Query build cache statistics |
+
+### `cmod/buildStatus` Notification
+
+Sent after `textDocument/didSave`. Payload:
+
+```json
+{
+  "modules": [
+    { "name": "mylib", "status": "up-to-date" },
+    { "name": "mylib:ops", "status": "needs-rebuild" }
+  ],
+  "summary": {
+    "total": 2,
+    "upToDate": 1,
+    "needsRebuild": 1,
+    "neverBuilt": 0
+  }
+}
+```
+
+### `cmod/dependencies` Request
+
+```json
+// Request params:
+{ "module": "mylib" }
+
+// Response:
+{ "dependencies": ["base"], "dependents": ["app"] }
+```
+
+### `cmod/criticalPath` Request
+
+```json
+// Response:
+{ "criticalPath": ["base", "mylib", "app"] }
+```
+
+### `cmod/cacheStatus` Request
+
+```json
+// Response:
+{ "entries": 42, "totalSizeBytes": 10485760 }
+```
+
+## Editor Configuration
+
+### Neovim (nvim-lspconfig)
+
+```lua
+local lspconfig = require('lspconfig')
+local configs = require('lspconfig.configs')
+
+configs.cmod = {
+  default_config = {
+    cmd = { 'cmod', 'lsp' },
+    filetypes = { 'cpp', 'cppm' },
+    root_dir = lspconfig.util.root_pattern('cmod.toml'),
+    settings = {},
+  },
+}
+
+lspconfig.cmod.setup{}
+```
+
+### VS Code
+
+Add to `.vscode/settings.json`:
+
+```json
+{
+  "cmod.lsp.path": "cmod",
+  "cmod.lsp.args": ["lsp"]
+}
+```
+
+Or use a generic LSP client extension with the command `cmod lsp`.
+
+### Emacs (eglot)
+
+```elisp
+(add-to-list 'eglot-server-programs
+             '((c++-mode) . ("cmod" "lsp")))
+```
+
+## Troubleshooting
+
+- **LSP not starting:** Ensure `cmod` is on your PATH and `cmod lsp` runs without errors.
+- **No completions:** Verify `cmod.toml` exists in the project root and lists dependencies.
+- **Missing diagnostics:** Check that source files are in the configured `[build].sources` directories (default: `src/`).
+- **Stale graph:** The module graph is cached for 30 seconds. Save `cmod.toml` to force a refresh.

--- a/docs/guide/plugins.md
+++ b/docs/guide/plugins.md
@@ -123,6 +123,18 @@ post-build = "plugin:my-reporter"
 
 This is equivalent to running `cmod plugin run my-analyzer` before the build.
 
+**Note:** Hook-invoked plugins do not receive CLI-style arguments. The hook
+dispatcher calls the plugin with an empty argument list, so syntax like
+`pre-build = "plugin:my-analyzer --strict"` is **not** supported. If your
+plugin needs configuration when run as a hook, use one of these alternatives:
+
+- Read settings from a config file in the project (e.g., `.cmod/plugins/my-analyzer/config.toml`)
+- Read environment variables (requires the `env` capability)
+- Read options from the `[plugins.my-analyzer]` table in `cmod.toml`
+
+To pass arguments interactively, invoke the plugin directly via the CLI:
+`cmod plugin run my-analyzer -- --strict`.
+
 ## Security
 
 ### Signature Verification

--- a/docs/guide/plugins.md
+++ b/docs/guide/plugins.md
@@ -1,0 +1,144 @@
+# Plugin Development Guide
+
+cmod supports plugins for extending build workflows, running custom analysis, and integrating external tools. Plugins communicate with cmod via a JSON IPC protocol over stdin/stdout.
+
+## Plugin Structure
+
+A plugin lives under `.cmod/plugins/<name>/` and consists of:
+
+```
+.cmod/plugins/my-plugin/
+├── plugin.toml          # Plugin manifest (required)
+├── bin/
+│   └── my-plugin        # Executable entry point
+└── plugin.sig           # Optional: signature file
+```
+
+## Plugin Manifest (`plugin.toml`)
+
+```toml
+capabilities = ["cli", "read_project"]
+
+[plugin]
+name = "my-plugin"
+version = "1.0.0"
+description = "What this plugin does"
+authors = ["Your Name"]
+license = "MIT"
+min_cmod_version = "0.1.0"
+entry_point = "bin/my-plugin"
+plugin_type = "script"     # "native", "script", or "wasm" (future)
+
+[limits]
+timeout_secs = 60
+max_memory_mb = 256
+max_files = 100
+max_output_mb = 10
+```
+
+## Capabilities
+
+Plugins declare required capabilities in `plugin.toml`. Unknown capabilities trigger a warning.
+
+| Capability | Aliases | Description |
+|---|---|---|
+| `read_project` | — | Read files within the project directory |
+| `write_project` | — | Write files within the project directory |
+| `read_manifest` | — | Read the cmod.toml manifest |
+| `write_manifest` | — | Modify the cmod.toml manifest |
+| `execute_commands` | `cli` | Execute shell commands |
+| `network_access` | `network` | Access the network |
+| `cache_access` | `cache` | Access the build cache |
+| `environment_access` | `env` | Access environment variables |
+| `dependency_graph_access` | `deps` | Access the dependency graph |
+| `build_plan_access` | `build` | Access the build plan |
+
+## JSON IPC Protocol
+
+### Request (stdin)
+
+cmod writes a single JSON line to the plugin's stdin:
+
+```json
+{
+  "action": "run",
+  "project_root": "/path/to/project",
+  "args": {
+    "greeting": "world",
+    "arg0": "positional-value"
+  }
+}
+```
+
+- `action` — always `"run"` for `cmod plugin run`
+- `project_root` — absolute path to the project root
+- `args` — key-value pairs from CLI arguments (`key=value` become entries; positional args become `arg0`, `arg1`, etc.)
+
+### Response (stdout)
+
+The plugin writes one or more JSON lines to stdout:
+
+```json
+{
+  "status": "ok",
+  "message": "Analysis complete: 0 issues found",
+  "data": { "issues": [] }
+}
+```
+
+- `status` — `"ok"` or `"error"`
+- `message` — human-readable message (displayed to the user)
+- `data` — optional structured data
+
+## Declaring Plugins in `cmod.toml`
+
+```toml
+[plugins.my-plugin]
+path = ".cmod/plugins/my-plugin"
+capabilities = ["cli", "read_project"]
+```
+
+## Running Plugins
+
+```bash
+# List discovered plugins
+cmod plugin list
+
+# Run a plugin
+cmod plugin run my-plugin
+
+# Pass arguments
+cmod plugin run my-plugin -- greeting=hello target=world
+```
+
+## Build Hook Integration
+
+Plugins can be invoked as build hooks using the `plugin:` prefix:
+
+```toml
+[hooks]
+pre-build = "plugin:my-analyzer"
+post-build = "plugin:my-reporter"
+```
+
+This is equivalent to running `cmod plugin run my-analyzer` before the build.
+
+## Security
+
+### Signature Verification
+
+If `[security].signature_policy` is configured in `cmod.toml`:
+
+- `"require"` — Unsigned plugins are rejected
+- `"warn"` — Unsigned plugins produce a warning
+- `"none"` — No signature checking (default)
+
+Sign a plugin by placing a `plugin.sig` file alongside `plugin.toml`.
+
+### Version Compatibility
+
+Set `min_cmod_version` in your plugin manifest to enforce a minimum cmod version. If the user's cmod is older, the plugin will refuse to run.
+
+## Example
+
+See [`examples/plugin/`](../../examples/plugin/) for a complete working example.

--- a/docs/rfc/rfc_0010_ide_integration_developer_experience.md
+++ b/docs/rfc/rfc_0010_ide_integration_developer_experience.md
@@ -1,7 +1,7 @@
 # RFC-0010: IDE Integration & Developer Experience
 
 ## Status
-Draft
+Implemented
 
 ## Summary
 This RFC defines the **IDE integration and developer experience** for **cmod**, focusing on how C++ modules are surfaced in editors, how builds interact with IDE tooling, and how developers can inspect, debug, and navigate module-based projects efficiently.

--- a/docs/rfc/rfc_0014_module_graph_visualization_developer_tools_enhancements.md
+++ b/docs/rfc/rfc_0014_module_graph_visualization_developer_tools_enhancements.md
@@ -1,7 +1,7 @@
 # RFC-0014: Module Graph Visualization & Developer Tools Enhancements
 
 ## Status
-Draft
+Implemented
 
 ## Summary
 This RFC defines the **module graph visualization and developer tooling enhancements** for **cmod**, providing better insights into module dependencies, build states, and performance metrics, integrated with IDEs and CLI tools.

--- a/docs/rfc/rfc_0018_tooling_plugins_ecosystem_utilities.md
+++ b/docs/rfc/rfc_0018_tooling_plugins_ecosystem_utilities.md
@@ -102,4 +102,4 @@ Recommended ecosystem tools:
 - Plugin-to-plugin communication
 
 ## Status
-**Draft**
+**Implemented** (WASM plugin runtime deferred)

--- a/examples/README.md
+++ b/examples/README.md
@@ -12,6 +12,7 @@ Working reference projects demonstrating cmod features and conventions.
 | [workspace](workspace/) | Multi-member monorepo | `[workspace]`, inter-member path deps, `{ workspace = true }`, shared lockfile |
 | [path-deps](path-deps/) | Local path dependencies | `path = "libs/..."`, co-located library development, `cmod deps --tree` |
 | [with-tests](with-tests/) | Testing with `cmod test` | `[test]` configuration, `tests/` directory convention, standalone test binaries |
+| [plugin](plugin/) | Plugin system | `[plugins]`, `plugin.toml` manifest, JSON IPC protocol, `cmod plugin run` |
 
 ## Getting started
 

--- a/examples/plugin/.cmod/plugins/hello-plugin/bin/hello-plugin
+++ b/examples/plugin/.cmod/plugins/hello-plugin/bin/hello-plugin
@@ -5,11 +5,12 @@
 # Usage: cmod plugin run hello-plugin -- greeting=world
 
 read -r INPUT
-GREETING=$(echo "$INPUT" | sed -n 's/.*"greeting":"\([^"]*\)".*/\1/p')
-PROJECT=$(echo "$INPUT" | sed -n 's/.*"project_root":"\([^"]*\)".*/\1/p')
 
-if [ -z "$GREETING" ]; then
-    GREETING="world"
-fi
-
-echo "{\"status\":\"ok\",\"message\":\"Hello, ${GREETING}! Project: ${PROJECT}\"}"
+# Use python3 for safe JSON parsing and output (available on macOS/Linux)
+python3 -c "
+import sys, json
+data = json.loads(sys.argv[1])
+greeting = data.get('args', {}).get('greeting', 'world')
+project = data.get('project_root', '')
+print(json.dumps({'status': 'ok', 'message': f'Hello, {greeting}! Project: {project}'}))
+" "$INPUT"

--- a/examples/plugin/.cmod/plugins/hello-plugin/bin/hello-plugin
+++ b/examples/plugin/.cmod/plugins/hello-plugin/bin/hello-plugin
@@ -1,0 +1,15 @@
+#!/bin/sh
+# hello-plugin — Example cmod plugin
+#
+# Reads a JSON request from stdin, outputs a JSON response to stdout.
+# Usage: cmod plugin run hello-plugin -- greeting=world
+
+read -r INPUT
+GREETING=$(echo "$INPUT" | sed -n 's/.*"greeting":"\([^"]*\)".*/\1/p')
+PROJECT=$(echo "$INPUT" | sed -n 's/.*"project_root":"\([^"]*\)".*/\1/p')
+
+if [ -z "$GREETING" ]; then
+    GREETING="world"
+fi
+
+echo "{\"status\":\"ok\",\"message\":\"Hello, ${GREETING}! Project: ${PROJECT}\"}"

--- a/examples/plugin/.cmod/plugins/hello-plugin/plugin.toml
+++ b/examples/plugin/.cmod/plugins/hello-plugin/plugin.toml
@@ -1,0 +1,13 @@
+capabilities = ["cli", "read_project"]
+
+[plugin]
+name = "hello-plugin"
+version = "1.0.0"
+description = "Example plugin that greets users"
+authors = ["cmod contributors"]
+entry_point = "bin/hello-plugin"
+plugin_type = "script"
+
+[limits]
+timeout_secs = 30
+max_memory_mb = 64

--- a/examples/plugin/cmod.toml
+++ b/examples/plugin/cmod.toml
@@ -1,0 +1,11 @@
+[package]
+name = "plugin-example"
+version = "0.1.0"
+
+[module]
+name = "plugin_example"
+root = "src/lib.cppm"
+
+[plugins.hello-plugin]
+path = ".cmod/plugins/hello-plugin"
+capabilities = ["cli", "read_project"]


### PR DESCRIPTION
Plugin SDK:
- Add argument passing to `cmod plugin run` via `-- key=value` pairs
- Add `min_cmod_version` validation against plugin manifests
- Wire signed plugin verification into plugin runner (warn/require policies)
- Add build hook `plugin:` prefix for dispatching hooks to plugins
- Add example plugin with JSON IPC protocol demonstration

LSP Server:
- Add `textDocument/documentSymbol` for outline/breadcrumb view
- Add `textDocument/references` for finding module importers
- Add `textDocument/codeAction` with quick fixes (missing import, semicolon)
- Add `cmod/buildStatus` notification emitted on save
- Add `cmod/dependencies`, `cmod/criticalPath`, `cmod/cacheStatus` queries
- Add diagnostic propagation through the module DAG
- Add module graph caching with 30s TTL and manifest-save invalidation
- Add completion provider refresh on cmod.toml save

Documentation:
- Add plugin development guide (docs/guide/plugins.md)
- Add IDE integration guide (docs/guide/ide-integration.md)
- Update CLI reference with plugin args and LSP docs
- Mark Phase 5 as complete in README, CLAUDE.md, CHANGELOG
- Mark RFC-0010, RFC-0014, RFC-0018 as Implemented

Tests: 753 → 781 (+28 new tests, 0 failures)

## Summary

<!-- Brief description of what this PR does and why. -->

## Changes

<!-- List the key changes made in this PR. -->

-

## Testing

- [ ] `cargo test --all` passes
- [ ] `cargo clippy --all-targets -- -D warnings` reports no warnings
- [ ] `cargo fmt --all --check` passes
- [ ] New functionality includes tests

## Related Issues

<!-- Link any related issues: Fixes #123, Relates to #456 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * LSP server: document symbols, references, code actions, diagnostics propagation, and new custom methods (buildStatus, dependencies, criticalPath, cacheStatus)
  * Plugin system: JSON IPC plugin SDK with key=value args support and signature/version checks; CLI accepts plugin args
  * Module graph caching (30s TTL) and build status notifications

* **Documentation**
  * IDE Integration Guide, Plugin Development Guide, and example plugin included
<!-- end of auto-generated comment: release notes by coderabbit.ai -->