### PR TITLE
docs: add binary publishing plan for cmod CLI and editor extensions

### DIFF
--- a/.github/workflows/release-clion.yml
+++ b/.github/workflows/release-clion.yml
@@ -53,10 +53,10 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: clion-plugin
-          path: plugin-artifacts
+          path: editors/clion/build/distributions
 
       - name: List artifacts
-        run: ls -la plugin-artifacts/
+        run: ls -la editors/clion/build/distributions/
 
       - name: Sign plugin
         if: ${{ secrets.JETBRAINS_CERTIFICATE_CHAIN != '' }}
@@ -80,4 +80,4 @@ jobs:
           tag_name: ${{ github.ref_name }}
           name: "CLion Plugin ${{ github.ref_name }}"
           generate_release_notes: true
-          files: plugin-artifacts/*.zip
+          files: editors/clion/build/distributions/*.zip

--- a/.github/workflows/release-clion.yml
+++ b/.github/workflows/release-clion.yml
@@ -59,7 +59,7 @@ jobs:
         run: ls -la plugin-artifacts/
 
       - name: Sign plugin
-        if: env.CERTIFICATE_CHAIN != ''
+        if: ${{ secrets.JETBRAINS_CERTIFICATE_CHAIN != '' }}
         working-directory: editors/clion
         run: ./gradlew signPlugin
         env:
@@ -68,7 +68,7 @@ jobs:
           PRIVATE_KEY_PASSWORD: ${{ secrets.JETBRAINS_PRIVATE_KEY_PASSWORD }}
 
       - name: Publish to JetBrains Marketplace
-        if: env.PUBLISH_TOKEN != ''
+        if: ${{ secrets.JETBRAINS_PUBLISH_TOKEN != '' }}
         working-directory: editors/clion
         run: ./gradlew publishPlugin
         env:

--- a/.github/workflows/release-clion.yml
+++ b/.github/workflows/release-clion.yml
@@ -1,0 +1,83 @@
+name: Release CLion Plugin
+
+on:
+  push:
+    tags:
+      - "clion-v*"
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build Plugin
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Build plugin
+        working-directory: editors/clion
+        run: ./gradlew buildPlugin
+
+      - name: Upload plugin artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: clion-plugin
+          path: editors/clion/build/distributions/*.zip
+
+  publish:
+    name: Publish Plugin
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: clion-plugin
+          path: plugin-artifacts
+
+      - name: List artifacts
+        run: ls -la plugin-artifacts/
+
+      - name: Sign plugin
+        if: env.CERTIFICATE_CHAIN != ''
+        working-directory: editors/clion
+        run: ./gradlew signPlugin
+        env:
+          CERTIFICATE_CHAIN: ${{ secrets.JETBRAINS_CERTIFICATE_CHAIN }}
+          PRIVATE_KEY: ${{ secrets.JETBRAINS_PRIVATE_KEY }}
+          PRIVATE_KEY_PASSWORD: ${{ secrets.JETBRAINS_PRIVATE_KEY_PASSWORD }}
+
+      - name: Publish to JetBrains Marketplace
+        if: env.PUBLISH_TOKEN != ''
+        working-directory: editors/clion
+        run: ./gradlew publishPlugin
+        env:
+          PUBLISH_TOKEN: ${{ secrets.JETBRAINS_PUBLISH_TOKEN }}
+
+      - name: Upload to GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: "CLion Plugin ${{ github.ref_name }}"
+          generate_release_notes: true
+          files: plugin-artifacts/*.zip

--- a/.github/workflows/release-vscode.yml
+++ b/.github/workflows/release-vscode.yml
@@ -168,7 +168,9 @@ jobs:
         working-directory: editors/vscode
         run: |
           npm ci
-          npx ovsx publish ../../vsix-artifacts/cmod-*.vsix -p "$OVSX_PAT"
+          # Publish only the universal VSIX (excludes platform-specific @target files)
+          UNIVERSAL_VSIX=$(ls ../../vsix-artifacts/cmod-*.vsix | grep -v '@' | head -1)
+          npx ovsx publish "$UNIVERSAL_VSIX" -p "$OVSX_PAT"
         env:
           OVSX_PAT: ${{ secrets.OVSX_PAT }}
 

--- a/.github/workflows/release-vscode.yml
+++ b/.github/workflows/release-vscode.yml
@@ -152,7 +152,7 @@ jobs:
         run: ls -la vsix-artifacts/
 
       - name: Publish to VS Code Marketplace
-        if: env.VSCE_PAT != ''
+        if: ${{ secrets.VSCE_PAT != '' }}
         working-directory: editors/vscode
         run: |
           npm ci
@@ -164,7 +164,7 @@ jobs:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
 
       - name: Publish to Open VSX
-        if: env.OVSX_PAT != ''
+        if: ${{ secrets.OVSX_PAT != '' }}
         working-directory: editors/vscode
         run: |
           npm ci

--- a/.github/workflows/release-vscode.yml
+++ b/.github/workflows/release-vscode.yml
@@ -1,0 +1,187 @@
+name: Release VS Code Extension
+
+on:
+  push:
+    tags:
+      - "vscode-v*"
+
+permissions:
+  contents: write
+
+jobs:
+  build-platform-vsix:
+    name: Build VSIX (${{ matrix.vscode-target }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - vscode-target: linux-x64
+            cmod-target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+          - vscode-target: linux-arm64
+            cmod-target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+          - vscode-target: alpine-x64
+            cmod-target: x86_64-unknown-linux-musl
+            os: ubuntu-latest
+          - vscode-target: darwin-x64
+            cmod-target: x86_64-apple-darwin
+            os: ubuntu-latest
+          - vscode-target: darwin-arm64
+            cmod-target: aarch64-apple-darwin
+            os: ubuntu-latest
+          - vscode-target: win32-x64
+            cmod-target: x86_64-pc-windows-msvc
+            os: ubuntu-latest
+          - vscode-target: win32-arm64
+            cmod-target: aarch64-pc-windows-msvc
+            os: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Extract cmod version
+        id: cmod-version
+        shell: bash
+        run: |
+          # Read the expected cmod binary version from package.json
+          CMOD_VERSION=$(node -e "console.log(require('./editors/vscode/package.json').cmod.binaryVersion)")
+          echo "version=v${CMOD_VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Download cmod binary from release
+        shell: bash
+        run: |
+          mkdir -p editors/vscode/bin
+          CMOD_VERSION="${{ steps.cmod-version.outputs.version }}"
+          TARGET="${{ matrix.cmod-target }}"
+
+          # Determine archive extension
+          if [[ "$TARGET" == *windows* ]]; then
+            EXT="zip"
+          else
+            EXT="tar.gz"
+          fi
+
+          ASSET_NAME="cmod-${CMOD_VERSION}-${TARGET}.${EXT}"
+          DOWNLOAD_URL="https://github.com/${{ github.repository }}/releases/download/${CMOD_VERSION}/${ASSET_NAME}"
+
+          echo "Downloading ${DOWNLOAD_URL}"
+          curl -fSL -o "archive.${EXT}" "${DOWNLOAD_URL}"
+
+          # Download and verify checksum
+          CHECKSUM_URL="https://github.com/${{ github.repository }}/releases/download/${CMOD_VERSION}/checksums-${CMOD_VERSION}.sha256"
+          curl -fSL -o checksums.sha256 "${CHECKSUM_URL}"
+          grep "${ASSET_NAME}" checksums.sha256 | sha256sum -c -
+
+          # Extract
+          if [[ "$EXT" == "zip" ]]; then
+            unzip "archive.zip" -d editors/vscode/bin/
+          else
+            tar xzf "archive.tar.gz" -C editors/vscode/bin/
+          fi
+
+          # Make executable on Unix
+          if [[ "$TARGET" != *windows* ]]; then
+            chmod +x editors/vscode/bin/cmod
+          fi
+
+          ls -la editors/vscode/bin/
+
+      - name: Install dependencies
+        working-directory: editors/vscode
+        run: npm ci
+
+      - name: Build platform-specific VSIX
+        working-directory: editors/vscode
+        run: npx vsce package --target ${{ matrix.vscode-target }}
+
+      - name: Upload VSIX artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: vsix-${{ matrix.vscode-target }}
+          path: editors/vscode/*.vsix
+
+  build-universal-vsix:
+    name: Build Universal VSIX
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        working-directory: editors/vscode
+        run: npm ci
+
+      - name: Build universal VSIX
+        working-directory: editors/vscode
+        run: npx vsce package
+
+      - name: Upload VSIX artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: vsix-universal
+          path: editors/vscode/*.vsix
+
+  publish:
+    name: Publish Extension
+    needs: [build-platform-vsix, build-universal-vsix]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: vsix-*
+          merge-multiple: true
+          path: vsix-artifacts
+
+      - name: List artifacts
+        run: ls -la vsix-artifacts/
+
+      - name: Publish to VS Code Marketplace
+        if: env.VSCE_PAT != ''
+        working-directory: editors/vscode
+        run: |
+          npm ci
+          for vsix in ../../vsix-artifacts/*-*.vsix; do
+            echo "Publishing $vsix to VS Code Marketplace"
+            npx vsce publish --packagePath "$vsix"
+          done
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+
+      - name: Publish to Open VSX
+        if: env.OVSX_PAT != ''
+        working-directory: editors/vscode
+        run: |
+          npm ci
+          npx ovsx publish ../../vsix-artifacts/cmod-*.vsix -p "$OVSX_PAT"
+        env:
+          OVSX_PAT: ${{ secrets.OVSX_PAT }}
+
+      - name: Extract version for release tag
+        id: version
+        run: |
+          TAG="${{ github.ref_name }}"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+
+      - name: Upload to GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: "VS Code Extension ${{ github.ref_name }}"
+          generate_release_notes: true
+          files: vsix-artifacts/*.vsix

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,12 +17,25 @@ jobs:
         include:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
+            archive: tar.gz
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-latest
+            archive: tar.gz
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-latest
+            archive: tar.gz
           - target: x86_64-apple-darwin
-            os: macos-latest
+            os: macos-13
+            archive: tar.gz
           - target: aarch64-apple-darwin
-            os: macos-latest
+            os: macos-14
+            archive: tar.gz
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+            archive: zip
+          - target: aarch64-pc-windows-msvc
+            os: windows-latest
+            archive: zip
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -30,29 +43,42 @@ jobs:
           targets: ${{ matrix.target }}
       - uses: Swatinem/rust-cache@v2
 
-      - name: Install cross-compilation tools
+      - name: Install cross-compilation tools (Linux ARM64)
         if: matrix.target == 'aarch64-unknown-linux-gnu'
         run: |
           sudo apt-get update
           sudo apt-get install -y gcc-aarch64-linux-gnu
+
+      - name: Install musl tools
+        if: matrix.target == 'x86_64-unknown-linux-musl'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y musl-tools
 
       - name: Build
         run: cargo build --release --target ${{ matrix.target }}
         env:
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
 
-      - name: Package
+      - name: Package (tar.gz)
+        if: matrix.archive == 'tar.gz'
         shell: bash
         run: |
           cd target/${{ matrix.target }}/release
           tar czf ../../../cmod-${{ github.ref_name }}-${{ matrix.target }}.tar.gz cmod
           cd ../../..
 
+      - name: Package (zip)
+        if: matrix.archive == 'zip'
+        shell: pwsh
+        run: |
+          Compress-Archive -Path "target/${{ matrix.target }}/release/cmod.exe" -DestinationPath "cmod-${{ github.ref_name }}-${{ matrix.target }}.zip"
+
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: cmod-${{ matrix.target }}
-          path: cmod-*.tar.gz
+          path: cmod-${{ github.ref_name }}-${{ matrix.target }}.*
 
   release:
     name: Create Release
@@ -64,8 +90,16 @@ jobs:
         with:
           merge-multiple: true
 
+      - name: Generate checksums
+        run: |
+          sha256sum cmod-${{ github.ref_name }}-*.tar.gz cmod-${{ github.ref_name }}-*.zip > checksums-${{ github.ref_name }}.sha256
+          cat checksums-${{ github.ref_name }}.sha256
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true
-          files: cmod-*.tar.gz
+          files: |
+            cmod-${{ github.ref_name }}-*.tar.gz
+            cmod-${{ github.ref_name }}-*.zip
+            checksums-${{ github.ref_name }}.sha256

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
             os: ubuntu-latest
             archive: tar.gz
           - target: x86_64-apple-darwin
-            os: macos-13
+            os: macos-15-large
             archive: tar.gz
           - target: aarch64-apple-darwin
             os: macos-14

--- a/docs/plan-binary-publishing.md
+++ b/docs/plan-binary-publishing.md
@@ -1,0 +1,290 @@
+# Binary Publishing Plan for cmod + Editor Extensions
+
+## Overview
+
+This plan covers three publishing pipelines:
+1. **cmod CLI binaries** — 7 platform targets via GitHub Releases
+2. **VS Code extension** — VS Code Marketplace, Open VSX Registry, GitHub Releases
+3. **CLion/IntelliJ plugin** — JetBrains Marketplace, GitHub Releases
+
+All extensions use **auto-download**: on first activation (or version mismatch), the extension downloads the matching cmod binary from GitHub Releases.
+
+---
+
+## 1. cmod CLI Binary Publishing
+
+### Targets (7 total)
+
+| Target Triple | OS | Arch | Runner | Notes |
+|---|---|---|---|---|
+| `x86_64-unknown-linux-gnu` | Linux | x64 | `ubuntu-latest` | Existing |
+| `aarch64-unknown-linux-gnu` | Linux | ARM64 | `ubuntu-latest` | Existing, cross-compiled |
+| `x86_64-unknown-linux-musl` | Linux | x64 | `ubuntu-latest` | **New**, static binary |
+| `x86_64-apple-darwin` | macOS | x64 | `macos-13` | Existing |
+| `aarch64-apple-darwin` | macOS | ARM64 | `macos-14` | Existing |
+| `x86_64-pc-windows-msvc` | Windows | x64 | `windows-latest` | **New** |
+| `aarch64-pc-windows-msvc` | Windows | ARM64 | `windows-latest` | **New**, cross-compiled |
+
+### Artifact naming
+
+```
+cmod-{version}-{target}.tar.gz      # Linux, macOS
+cmod-{version}-{target}.zip         # Windows
+```
+
+### Checksums
+
+Generate `checksums-{version}.sha256` containing SHA-256 hashes of all artifacts. Attach to the GitHub Release.
+
+### Changes to `release.yml`
+
+- Expand the build matrix to 7 targets
+- Install `musl-tools` for the musl target
+- Add Windows targets with `.zip` packaging (not `.tar.gz`)
+- Add a checksum generation job that runs after all builds complete
+- Add code signing steps (placeholder, configurable via secrets):
+  - macOS: `codesign` with Developer ID (optional)
+  - Windows: `signtool` with Authenticode cert (optional)
+
+---
+
+## 2. VS Code Extension Publishing
+
+### Build & Packaging
+
+The VS Code extension is a standard TypeScript/Webpack project. It produces a `.vsix` package.
+
+**Platform-specific VSIX:** Use `@vscode/vsce`'s `--target` flag to produce platform-specific extensions. This enables the VS Code Marketplace to serve the right package per platform. Targets:
+- `linux-x64`, `linux-arm64`, `linux-x64-musl` (Alpine)
+- `darwin-x64`, `darwin-arm64`
+- `win32-x64`, `win32-arm64`
+
+Each platform-specific VSIX bundles the matching cmod binary for zero-config experience on marketplace installs. For GitHub Release `.vsix` files, a universal (non-platform-specific) VSIX is also produced that uses auto-download.
+
+### Auto-download mechanism (for universal VSIX / fallback)
+
+On activation, the extension:
+1. Checks if `cmod` exists at the expected location (`~/.cmod/bin/cmod` or extension storage)
+2. Checks version matches (`cmod --version` vs extension's expected version)
+3. If missing or outdated:
+   - Detects platform/arch via `process.platform` + `process.arch`
+   - Fetches the GitHub Releases API: `GET /repos/satishbabariya/cmod/releases/tags/v{version}`
+   - Downloads the matching tarball/zip
+   - Verifies SHA-256 checksum against `checksums-{version}.sha256`
+   - Extracts binary to `globalStorageUri/bin/cmod`
+   - Sets executable permissions on Unix
+4. Adds the binary path to the extension's LSP server configuration
+
+### Publishing targets
+
+| Target | Method | Secrets Required |
+|---|---|---|
+| VS Code Marketplace | `vsce publish` | `VSCE_PAT` (Personal Access Token) |
+| Open VSX Registry | `ovsx publish` | `OVSX_PAT` (Personal Access Token) |
+| GitHub Release | Upload `.vsix` as release asset | `GITHUB_TOKEN` (automatic) |
+
+### Workflow: `.github/workflows/release-vscode.yml`
+
+**Trigger:** Tag push matching `vscode-v*` (e.g., `vscode-v0.1.0`)
+
+**Jobs:**
+
+1. **build-platform-vsix** (matrix: 7 VS Code targets)
+   - Checkout
+   - Setup Node.js 20
+   - `npm ci` in `editors/vscode/`
+   - Download matching cmod binary from the GitHub Release (requires cmod release first)
+   - Place binary in `editors/vscode/bin/cmod` (or `cmod.exe`)
+   - `vsce package --target {target}` → produces `cmod-{target}-{version}.vsix`
+   - Upload as artifact
+
+2. **build-universal-vsix**
+   - Same as above but no `--target` flag, no bundled binary
+   - Produces `cmod-{version}.vsix` (universal, uses auto-download)
+
+3. **publish**
+   - Download all VSIX artifacts
+   - `vsce publish` (each platform-specific VSIX) → VS Code Marketplace
+   - `ovsx publish` (universal VSIX) → Open VSX
+   - Upload all `.vsix` files to GitHub Release
+
+### Version coordination
+
+The VS Code extension's `package.json` version and its expected cmod version are kept in sync. The extension stores the compatible cmod version in `package.json` under a custom field:
+
+```json
+{
+  "version": "0.1.0",
+  "cmod": {
+    "binaryVersion": "0.1.0"
+  }
+}
+```
+
+---
+
+## 3. CLion/IntelliJ Plugin Publishing
+
+### Build & Packaging
+
+The CLion plugin is a Gradle/Kotlin project. It produces a `.zip` file via `./gradlew buildPlugin`.
+
+Unlike VS Code, JetBrains plugins are platform-independent (JVM-based), so a single `.zip` is published. The auto-download mechanism handles platform-specific binary acquisition at runtime.
+
+### Auto-download mechanism
+
+On IDE startup (or plugin activation), the plugin:
+1. Checks if `cmod` exists at the expected location (`~/.cmod/bin/cmod`)
+2. Checks version via `cmod --version`
+3. If missing/outdated:
+   - Detects OS/arch via `System.getProperty("os.name")` + `System.getProperty("os.arch")`
+   - Downloads from GitHub Releases (same API as VS Code)
+   - Verifies SHA-256 checksum
+   - Extracts to plugin data directory (`PathManager.getPluginDataPath()`)
+   - Sets executable bit on Unix via `File.setExecutable(true)`
+4. Configures the LSP server to use the downloaded binary
+
+### Publishing targets
+
+| Target | Method | Secrets Required |
+|---|---|---|
+| JetBrains Marketplace | `./gradlew publishPlugin` | `JETBRAINS_PUBLISH_TOKEN` |
+| GitHub Release | Upload `.zip` as release asset | `GITHUB_TOKEN` |
+
+### Workflow: `.github/workflows/release-clion.yml`
+
+**Trigger:** Tag push matching `clion-v*` (e.g., `clion-v0.1.0`)
+
+**Jobs:**
+
+1. **build**
+   - Checkout
+   - Setup JDK 17
+   - `./gradlew buildPlugin` in `editors/clion/`
+   - Upload `.zip` artifact
+
+2. **publish**
+   - Download artifact
+   - `./gradlew publishPlugin` → JetBrains Marketplace
+   - Upload `.zip` to GitHub Release
+
+### Version coordination
+
+The plugin's `build.gradle.kts` stores the compatible cmod version:
+
+```kotlin
+val cmodBinaryVersion = "0.1.0"
+```
+
+This is embedded in the plugin resources and used by the auto-download logic.
+
+---
+
+## 4. Release Orchestration
+
+### Tag conventions
+
+| Component | Tag pattern | Example |
+|---|---|---|
+| cmod CLI | `v*` | `v0.1.0` |
+| VS Code extension | `vscode-v*` | `vscode-v0.1.0` |
+| CLion plugin | `clion-v*` | `clion-v0.1.0` |
+
+### Release order
+
+For a coordinated release:
+1. Push `v0.1.0` tag → builds + publishes cmod binaries to GitHub Release
+2. Wait for release to complete
+3. Push `vscode-v0.1.0` tag → builds VS Code extension (downloads cmod from step 1), publishes
+4. Push `clion-v0.1.0` tag → builds CLion plugin, publishes
+
+Extensions can also be released independently (e.g., bug fixes that don't require a new cmod binary).
+
+### Future: unified release workflow
+
+A single `release-all.yml` workflow triggered by `v*` tags could orchestrate all three in sequence using workflow dispatch or job dependencies. Defer this until the independent workflows are proven.
+
+---
+
+## 5. Auto-download Implementation Details
+
+### Shared logic
+
+Both extensions implement the same download logic. Key design decisions:
+
+**Download URL pattern:**
+```
+https://github.com/satishbabariya/cmod/releases/download/v{version}/cmod-v{version}-{target}.tar.gz
+https://github.com/satishbabariya/cmod/releases/download/v{version}/cmod-v{version}-{target}.zip
+```
+
+**Platform mapping:**
+
+| Extension platform | cmod target triple |
+|---|---|
+| VS Code `linux-x64` / CLion `Linux x86_64` | `x86_64-unknown-linux-gnu` |
+| VS Code `linux-arm64` / CLion `Linux aarch64` | `aarch64-unknown-linux-gnu` |
+| VS Code `alpine-x64` | `x86_64-unknown-linux-musl` |
+| VS Code `darwin-x64` / CLion `Mac OS X x86_64` | `x86_64-apple-darwin` |
+| VS Code `darwin-arm64` / CLion `Mac OS X aarch64` | `aarch64-apple-darwin` |
+| VS Code `win32-x64` / CLion `Windows x86_64` | `x86_64-pc-windows-msvc` |
+| VS Code `win32-arm64` / CLion `Windows aarch64` | `aarch64-pc-windows-msvc` |
+
+**Checksum verification:**
+1. Download `checksums-{version}.sha256` from the release
+2. Compute SHA-256 of downloaded archive
+3. Compare against expected hash
+4. Reject on mismatch with user-facing error
+
+**User experience:**
+- Show progress notification during download
+- Allow cancellation
+- Provide a "Download failed" error with link to manual install docs
+- Respect proxy settings (`http.proxy` in VS Code, IDE proxy in CLion)
+- Support `cmod.binaryPath` setting to override auto-download with a user-supplied path
+
+**Binary storage location:**
+- VS Code: `globalStorageUri/bin/cmod` (managed by VS Code, survives extension updates)
+- CLion: `PathManager.getPluginDataPath()/cmod/bin/cmod`
+
+---
+
+## 6. Files to Create/Modify
+
+### New files
+
+| File | Purpose |
+|---|---|
+| `.github/workflows/release-vscode.yml` | VS Code extension release workflow |
+| `.github/workflows/release-clion.yml` | CLion plugin release workflow |
+| `editors/vscode/src/binary.ts` | Auto-download logic for VS Code |
+| `editors/clion/src/main/kotlin/com/cmod/intellij/binary/BinaryManager.kt` | Auto-download logic for CLion |
+
+### Modified files
+
+| File | Changes |
+|---|---|
+| `.github/workflows/release.yml` | Add Windows + musl targets, checksum job, code signing placeholders |
+| `editors/vscode/package.json` | Add `cmod.binaryVersion`, `cmod.binaryPath` setting |
+| `editors/vscode/src/extension.ts` | Call binary manager on activation |
+| `editors/clion/build.gradle.kts` | Add `cmodBinaryVersion` property |
+| `editors/clion/src/main/resources/META-INF/plugin.xml` | Register binary manager service |
+
+---
+
+## 7. Security Considerations
+
+- **Checksum verification** on every download (SHA-256)
+- **HTTPS only** for all downloads
+- **No arbitrary code execution** — only the verified cmod binary is executed
+- **User consent** — show notification before downloading, allow opt-out via `cmod.binaryPath`
+- **Future:** GPG signature verification on release artifacts (cmod-security already has the primitives)
+
+---
+
+## 8. Open Questions
+
+1. **Homebrew / winget / APT?** Should we also publish to OS package managers? (Deferred — GitHub Releases is sufficient for now)
+2. **cargo-binstall support?** Adding `[package.metadata.binstall]` to Cargo.toml enables `cargo binstall cmod`. Low effort, nice-to-have.
+3. **Nightly/pre-release channel?** Could publish from `main` branch pushes. Deferred.
+4. **Extension telemetry?** Track auto-download success/failure rates. Deferred.

--- a/docs/plan-binary-publishing.md
+++ b/docs/plan-binary-publishing.md
@@ -55,7 +55,7 @@ Generate `checksums-{version}.sha256` containing SHA-256 hashes of all artifacts
 The VS Code extension is a standard TypeScript/Webpack project. It produces a `.vsix` package.
 
 **Platform-specific VSIX:** Use `@vscode/vsce`'s `--target` flag to produce platform-specific extensions. This enables the VS Code Marketplace to serve the right package per platform. Targets:
-- `linux-x64`, `linux-arm64`, `linux-x64-musl` (Alpine)
+- `linux-x64`, `linux-arm64`, `alpine-x64` (musl libc)
 - `darwin-x64`, `darwin-arm64`
 - `win32-x64`, `win32-arm64`
 
@@ -257,7 +257,7 @@ https://github.com/satishbabariya/cmod/releases/download/v{version}/cmod-v{versi
 |---|---|
 | `.github/workflows/release-vscode.yml` | VS Code extension release workflow |
 | `.github/workflows/release-clion.yml` | CLion plugin release workflow |
-| `editors/vscode/src/binary.ts` | Auto-download logic for VS Code |
+| `editors/vscode/src/utils/binaryManager.ts` | Auto-download logic for VS Code |
 | `editors/clion/src/main/kotlin/com/cmod/intellij/binary/BinaryManager.kt` | Auto-download logic for CLion |
 
 ### Modified files

--- a/editors/clion/build.gradle.kts
+++ b/editors/clion/build.gradle.kts
@@ -7,6 +7,9 @@ plugins {
 group = "com.cmod.intellij"
 version = "0.1.0"
 
+/** The cmod CLI version this plugin expects. Used by BinaryManager for auto-download. */
+val cmodBinaryVersion = "0.1.0"
+
 repositories {
     mavenCentral()
     intellijPlatform {
@@ -54,5 +57,11 @@ tasks {
 
     buildSearchableOptions {
         enabled = false
+    }
+
+    processResources {
+        filesMatching("cmod.properties") {
+            expand("cmodBinaryVersion" to cmodBinaryVersion)
+        }
     }
 }

--- a/editors/clion/src/main/kotlin/com/cmod/intellij/binary/BinaryManager.kt
+++ b/editors/clion/src/main/kotlin/com/cmod/intellij/binary/BinaryManager.kt
@@ -102,9 +102,7 @@ class BinaryManager {
     }
 
     private fun downloadBinary(platformInfo: PlatformInfo): String? {
-        var result: String? = null
-
-        ProgressManager.getInstance().run(object : Task.WithResult<String?, Exception>(
+        val task = object : Task.WithResult<String?, Exception>(
             null,
             "Downloading cmod v$EXPECTED_VERSION",
             true
@@ -128,6 +126,7 @@ class BinaryManager {
                     // Download and verify checksum
                     indicator.text = "Verifying checksum..."
                     indicator.fraction = 0.8
+                    var checksumVerified = false
                     try {
                         val checksumsBytes = downloadUrl(checksumsUrl, null)
                         val checksumsText = String(checksumsBytes, Charsets.UTF_8)
@@ -142,9 +141,34 @@ class BinaryManager {
                                 return null
                             }
                             LOG.info("Checksum verified: $actualHash")
+                            checksumVerified = true
+                        } else {
+                            LOG.warn("No checksum found for $archiveName in checksums file")
                         }
                     } catch (e: Exception) {
-                        LOG.warn("Could not verify checksum: ${e.message}")
+                        LOG.error("Checksum verification failed: ${e.message}", e)
+                        val settings = CmodSettingsState.getInstance()
+                        if (!settings.allowUnverifiedBinaries) {
+                            notify(
+                                "cmod download failed: could not verify checksum. " +
+                                "Enable 'Allow Unverified Binaries' in settings to bypass.",
+                                NotificationType.ERROR
+                            )
+                            return null
+                        }
+                        notify(
+                            "Warning: cmod binary checksum could not be verified. Proceeding due to settings override.",
+                            NotificationType.WARNING
+                        )
+                    }
+
+                    if (!checksumVerified && !CmodSettingsState.getInstance().allowUnverifiedBinaries) {
+                        LOG.error("Checksum not verified and allowUnverifiedBinaries is disabled")
+                        notify(
+                            "cmod download failed: checksum verification required but not completed.",
+                            NotificationType.ERROR
+                        )
+                        return null
                     }
 
                     // Extract binary
@@ -178,9 +202,9 @@ class BinaryManager {
                     return null
                 }
             }
-        }.also { result = it.compute(ProgressManager.getInstance().progressIndicator ?: EmptyProgressIndicator()) })
+        }
 
-        return result
+        return ProgressManager.getInstance().run(task)
     }
 
     private fun downloadUrl(url: String, indicator: ProgressIndicator?): ByteArray {

--- a/editors/clion/src/main/kotlin/com/cmod/intellij/binary/BinaryManager.kt
+++ b/editors/clion/src/main/kotlin/com/cmod/intellij/binary/BinaryManager.kt
@@ -1,0 +1,391 @@
+package com.cmod.intellij.binary
+
+import com.cmod.intellij.settings.CmodSettingsState
+import com.intellij.notification.NotificationGroupManager
+import com.intellij.notification.NotificationType
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.PathManager
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.progress.ProgressIndicator
+import com.intellij.openapi.progress.ProgressManager
+import com.intellij.openapi.progress.Task
+import com.intellij.openapi.util.SystemInfo
+import java.io.*
+import java.net.HttpURLConnection
+import java.net.URI
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.security.MessageDigest
+import java.util.zip.GZIPInputStream
+import java.util.zip.ZipInputStream
+
+/**
+ * Manages downloading, verifying, and locating the cmod binary.
+ *
+ * On first use (or version mismatch), downloads the platform-appropriate
+ * binary from GitHub Releases, verifies its SHA-256 checksum, and
+ * extracts it to the plugin's data directory.
+ */
+@Service(Service.Level.APP)
+class BinaryManager {
+
+    companion object {
+        private val LOG = Logger.getInstance(BinaryManager::class.java)
+        private const val GITHUB_REPO = "satishbabariya/cmod"
+        private const val EXPECTED_VERSION = "0.1.0"
+
+        fun getInstance(): BinaryManager {
+            return ApplicationManager.getApplication().getService(BinaryManager::class.java)
+        }
+    }
+
+    private val binaryName = if (SystemInfo.isWindows) "cmod.exe" else "cmod"
+    private val binDir: Path = Paths.get(PathManager.getPluginDataPath(), "cmod", "bin")
+
+    /**
+     * Returns the path to the cmod binary, downloading if necessary.
+     *
+     * Resolution order:
+     * 1. User-configured path in settings
+     * 2. Previously downloaded binary in plugin data directory
+     * 3. System PATH / common locations
+     * 4. Auto-download from GitHub Releases
+     */
+    fun ensureBinary(): String? {
+        // 1. User-configured path
+        val settings = CmodSettingsState.getInstance()
+        if (settings.cmodBinaryPath.isNotBlank()) {
+            val configured = File(settings.cmodBinaryPath)
+            if (configured.exists() && configured.canExecute()) {
+                LOG.info("Using configured cmod binary: ${configured.absolutePath}")
+                return configured.absolutePath
+            }
+            LOG.warn("Configured cmod path not found: ${settings.cmodBinaryPath}")
+        }
+
+        // 2. Previously downloaded binary
+        val managedPath = binDir.resolve(binaryName)
+        if (Files.exists(managedPath) && Files.isExecutable(managedPath)) {
+            val version = getVersion(managedPath.toString())
+            if (version != null && version.contains(EXPECTED_VERSION)) {
+                LOG.info("Using managed cmod binary: $managedPath ($version)")
+                return managedPath.toString()
+            }
+            LOG.info("Managed binary version mismatch (got $version, want $EXPECTED_VERSION)")
+        }
+
+        // 3. System PATH and common locations
+        val systemBinary = findOnSystem()
+        if (systemBinary != null) {
+            val version = getVersion(systemBinary)
+            if (version != null && version.contains(EXPECTED_VERSION)) {
+                LOG.info("Using system cmod binary: $systemBinary ($version)")
+                return systemBinary
+            }
+            LOG.info("System cmod version mismatch (got $version, want $EXPECTED_VERSION)")
+        }
+
+        // 4. Auto-download
+        val platformInfo = getPlatformInfo()
+        if (platformInfo == null) {
+            LOG.warn("Unsupported platform: ${SystemInfo.OS_NAME} / ${SystemInfo.OS_ARCH}")
+            notify(
+                "Unsupported platform for cmod auto-download. Please install cmod manually.",
+                NotificationType.ERROR
+            )
+            return systemBinary
+        }
+
+        return downloadBinary(platformInfo)
+    }
+
+    private fun downloadBinary(platformInfo: PlatformInfo): String? {
+        var result: String? = null
+
+        ProgressManager.getInstance().run(object : Task.WithResult<String?, Exception>(
+            null,
+            "Downloading cmod v$EXPECTED_VERSION",
+            true
+        ) {
+            override fun compute(indicator: ProgressIndicator): String? {
+                indicator.isIndeterminate = false
+                indicator.text = "Downloading cmod v$EXPECTED_VERSION..."
+
+                val version = "v$EXPECTED_VERSION"
+                val archiveName = "cmod-$version-${platformInfo.target}.${platformInfo.archiveExt}"
+                val archiveUrl = "https://github.com/$GITHUB_REPO/releases/download/$version/$archiveName"
+                val checksumsUrl = "https://github.com/$GITHUB_REPO/releases/download/$version/checksums-$version.sha256"
+
+                try {
+                    // Download archive
+                    LOG.info("Downloading $archiveUrl")
+                    val archiveBytes = downloadUrl(archiveUrl, indicator)
+
+                    if (indicator.isCanceled) return null
+
+                    // Download and verify checksum
+                    indicator.text = "Verifying checksum..."
+                    indicator.fraction = 0.8
+                    try {
+                        val checksumsBytes = downloadUrl(checksumsUrl, null)
+                        val checksumsText = String(checksumsBytes, Charsets.UTF_8)
+                        val expectedHash = parseChecksumForFile(checksumsText, archiveName)
+
+                        if (expectedHash != null) {
+                            val digest = MessageDigest.getInstance("SHA-256")
+                            val actualHash = digest.digest(archiveBytes).joinToString("") { "%02x".format(it) }
+                            if (actualHash != expectedHash) {
+                                LOG.error("Checksum mismatch: expected=$expectedHash, actual=$actualHash")
+                                notify("cmod download failed: checksum mismatch", NotificationType.ERROR)
+                                return null
+                            }
+                            LOG.info("Checksum verified: $actualHash")
+                        }
+                    } catch (e: Exception) {
+                        LOG.warn("Could not verify checksum: ${e.message}")
+                    }
+
+                    // Extract binary
+                    indicator.text = "Extracting binary..."
+                    indicator.fraction = 0.9
+                    Files.createDirectories(binDir)
+
+                    val destPath = binDir.resolve(binaryName)
+                    if (platformInfo.archiveExt == "tar.gz") {
+                        extractTarGz(archiveBytes, destPath.toString(), binaryName)
+                    } else {
+                        extractZip(archiveBytes, destPath.toString(), binaryName)
+                    }
+
+                    // Set executable permission on Unix
+                    if (!SystemInfo.isWindows) {
+                        destPath.toFile().setExecutable(true, false)
+                    }
+
+                    indicator.fraction = 1.0
+                    LOG.info("cmod binary installed to $destPath")
+                    notify("cmod v$EXPECTED_VERSION downloaded successfully.", NotificationType.INFORMATION)
+
+                    return destPath.toString()
+                } catch (e: Exception) {
+                    LOG.error("Failed to download cmod binary", e)
+                    notify(
+                        "Failed to download cmod: ${e.message}. Please install manually.",
+                        NotificationType.ERROR
+                    )
+                    return null
+                }
+            }
+        }.also { result = it.compute(ProgressManager.getInstance().progressIndicator ?: EmptyProgressIndicator()) })
+
+        return result
+    }
+
+    private fun downloadUrl(url: String, indicator: ProgressIndicator?): ByteArray {
+        var currentUrl = url
+        var redirectCount = 0
+        while (redirectCount < 10) {
+            val connection = URI(currentUrl).toURL().openConnection() as HttpURLConnection
+            connection.setRequestProperty("User-Agent", "cmod-clion")
+            connection.instanceFollowRedirects = false
+            connection.connect()
+
+            val responseCode = connection.responseCode
+            if (responseCode in 300..399) {
+                currentUrl = connection.getHeaderField("Location")
+                    ?: throw IOException("Redirect with no Location header")
+                redirectCount++
+                connection.disconnect()
+                continue
+            }
+
+            if (responseCode != 200) {
+                connection.disconnect()
+                throw IOException("HTTP $responseCode for $currentUrl")
+            }
+
+            val totalBytes = connection.contentLengthLong
+            val output = ByteArrayOutputStream()
+            connection.inputStream.use { input ->
+                val buffer = ByteArray(8192)
+                var bytesRead: Int
+                var totalRead = 0L
+                while (input.read(buffer).also { bytesRead = it } != -1) {
+                    output.write(buffer, 0, bytesRead)
+                    totalRead += bytesRead
+                    if (indicator != null && totalBytes > 0) {
+                        indicator.fraction = totalRead.toDouble() / totalBytes * 0.8
+                    }
+                }
+            }
+            connection.disconnect()
+            return output.toByteArray()
+        }
+        throw IOException("Too many redirects for $url")
+    }
+
+    private fun extractTarGz(archiveBytes: ByteArray, destPath: String, binaryName: String) {
+        val gzipInput = GZIPInputStream(ByteArrayInputStream(archiveBytes))
+        val tarBytes = gzipInput.readBytes()
+        gzipInput.close()
+
+        // Simple tar parser: 512-byte headers
+        var offset = 0
+        while (offset < tarBytes.size - 512) {
+            val header = tarBytes.sliceArray(offset until offset + 512)
+            if (header.all { it == 0.toByte() }) break
+
+            val fileName = String(header, 0, 100, Charsets.UTF_8).trimEnd('\u0000').trim()
+            val sizeStr = String(header, 124, 12, Charsets.UTF_8).trimEnd('\u0000').trim()
+            val fileSize = if (sizeStr.isNotEmpty()) sizeStr.toLong(8) else 0L
+
+            offset += 512 // Past header
+
+            if (fileName == binaryName || fileName.endsWith("/$binaryName")) {
+                val fileData = tarBytes.sliceArray(offset until offset + fileSize.toInt())
+                File(destPath).writeBytes(fileData)
+                return
+            }
+
+            offset += (Math.ceil(fileSize.toDouble() / 512) * 512).toInt()
+        }
+        throw IOException("Binary '$binaryName' not found in tar.gz archive")
+    }
+
+    private fun extractZip(archiveBytes: ByteArray, destPath: String, binaryName: String) {
+        ZipInputStream(ByteArrayInputStream(archiveBytes)).use { zis ->
+            var entry = zis.nextEntry
+            while (entry != null) {
+                val name = entry.name
+                if (name == binaryName || name.endsWith("/$binaryName")) {
+                    File(destPath).outputStream().use { out ->
+                        zis.copyTo(out)
+                    }
+                    return
+                }
+                entry = zis.nextEntry
+            }
+        }
+        throw IOException("Binary '$binaryName' not found in zip archive")
+    }
+
+    private fun parseChecksumForFile(checksumsText: String, fileName: String): String? {
+        for (line in checksumsText.lines()) {
+            val trimmed = line.trim()
+            if (trimmed.isEmpty()) continue
+            val parts = trimmed.split(Regex("\\s+"))
+            if (parts.size >= 2) {
+                val hash = parts[0]
+                val name = parts.last().removePrefix("*")
+                if (name == fileName || name.endsWith("/$fileName")) {
+                    return hash
+                }
+            }
+        }
+        return null
+    }
+
+    private fun getVersion(binaryPath: String): String? {
+        return try {
+            val process = ProcessBuilder(binaryPath, "--version")
+                .redirectErrorStream(true)
+                .start()
+            val output = process.inputStream.bufferedReader().readText().trim()
+            val exitCode = process.waitFor()
+            if (exitCode == 0) output else null
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    private fun findOnSystem(): String? {
+        // Search PATH
+        val pathEnv = System.getenv("PATH") ?: ""
+        val separator = if (SystemInfo.isWindows) ";" else ":"
+        for (dir in pathEnv.split(separator)) {
+            val candidate = Paths.get(dir, binaryName)
+            if (Files.exists(candidate) && Files.isExecutable(candidate)) {
+                return candidate.toAbsolutePath().toString()
+            }
+        }
+
+        // Common install locations
+        val commonPaths = listOf(
+            Paths.get(System.getProperty("user.home"), ".cargo", "bin", binaryName),
+            Paths.get(System.getProperty("user.home"), ".local", "bin", binaryName),
+            Paths.get("/usr", "local", "bin", binaryName),
+            Paths.get("/opt", "homebrew", "bin", binaryName),
+        )
+        for (p in commonPaths) {
+            if (Files.exists(p) && Files.isExecutable(p)) {
+                return p.toAbsolutePath().toString()
+            }
+        }
+        return null
+    }
+
+    private fun notify(message: String, type: NotificationType) {
+        ApplicationManager.getApplication().invokeLater {
+            NotificationGroupManager.getInstance()
+                .getNotificationGroup("cmod.notifications")
+                .createNotification(message, type)
+                .notify(null)
+        }
+    }
+
+    data class PlatformInfo(
+        val target: String,
+        val archiveExt: String,
+    )
+
+    private fun getPlatformInfo(): PlatformInfo? {
+        val osName = SystemInfo.OS_NAME.lowercase()
+        val arch = System.getProperty("os.arch")?.lowercase() ?: return null
+
+        return when {
+            SystemInfo.isLinux && (arch == "amd64" || arch == "x86_64") ->
+                PlatformInfo("x86_64-unknown-linux-gnu", "tar.gz")
+            SystemInfo.isLinux && (arch == "aarch64" || arch == "arm64") ->
+                PlatformInfo("aarch64-unknown-linux-gnu", "tar.gz")
+            SystemInfo.isMac && (arch == "amd64" || arch == "x86_64") ->
+                PlatformInfo("x86_64-apple-darwin", "tar.gz")
+            SystemInfo.isMac && (arch == "aarch64" || arch == "arm64") ->
+                PlatformInfo("aarch64-apple-darwin", "tar.gz")
+            SystemInfo.isWindows && (arch == "amd64" || arch == "x86_64") ->
+                PlatformInfo("x86_64-pc-windows-msvc", "zip")
+            SystemInfo.isWindows && (arch == "aarch64" || arch == "arm64") ->
+                PlatformInfo("aarch64-pc-windows-msvc", "zip")
+            else -> null
+        }
+    }
+
+    /**
+     * Minimal progress indicator for non-UI contexts.
+     */
+    private class EmptyProgressIndicator : ProgressIndicator {
+        override fun start() {}
+        override fun stop() {}
+        override fun isRunning(): Boolean = true
+        override fun cancel() {}
+        override fun isCanceled(): Boolean = false
+        override fun setText(text: String?) {}
+        override fun getText(): String = ""
+        override fun setText2(text: String?) {}
+        override fun getText2(): String = ""
+        override fun getFraction(): Double = 0.0
+        override fun setFraction(fraction: Double) {}
+        override fun pushState() {}
+        override fun popState() {}
+        override fun isModal(): Boolean = false
+        override fun getModalityState(): com.intellij.openapi.application.ModalityState =
+            com.intellij.openapi.application.ModalityState.nonModal()
+        override fun setModalityState(modalityState: com.intellij.openapi.application.ModalityState) {}
+        override fun isIndeterminate(): Boolean = true
+        override fun setIndeterminate(indeterminate: Boolean) {}
+        override fun checkCanceled() {}
+        override fun isPopupWasShown(): Boolean = false
+        override fun isShowing(): Boolean = false
+    }
+}

--- a/editors/clion/src/main/kotlin/com/cmod/intellij/settings/CmodSettingsState.kt
+++ b/editors/clion/src/main/kotlin/com/cmod/intellij/settings/CmodSettingsState.kt
@@ -55,6 +55,14 @@ class CmodSettingsState : PersistentStateComponent<CmodSettingsState> {
      */
     var lintOnSave: Boolean = false
 
+    /**
+     * Whether to allow using binaries that could not be verified.
+     * When false (default), checksum verification failures abort download.
+     * Only enable this if you trust the download source and verification
+     * is failing due to network or infrastructure issues.
+     */
+    var allowUnverifiedBinaries: Boolean = false
+
     companion object {
         fun getInstance(): CmodSettingsState {
             return ApplicationManager.getApplication().getService(CmodSettingsState::class.java)
@@ -71,5 +79,6 @@ class CmodSettingsState : PersistentStateComponent<CmodSettingsState> {
         showBuildNotifications = state.showBuildNotifications
         formatOnSave = state.formatOnSave
         lintOnSave = state.lintOnSave
+        allowUnverifiedBinaries = state.allowUnverifiedBinaries
     }
 }

--- a/editors/clion/src/main/kotlin/com/cmod/intellij/util/CmodBinaryUtil.kt
+++ b/editors/clion/src/main/kotlin/com/cmod/intellij/util/CmodBinaryUtil.kt
@@ -1,5 +1,6 @@
 package com.cmod.intellij.util
 
+import com.cmod.intellij.binary.BinaryManager
 import com.cmod.intellij.settings.CmodSettingsState
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.util.SystemInfo
@@ -11,10 +12,15 @@ import java.nio.file.Paths
 /**
  * Utility for locating the cmod binary on the system.
  *
+ * Delegates to [BinaryManager] which handles auto-download when the binary
+ * is not found locally.
+ *
  * Search order:
  * 1. User-configured path in settings
- * 2. PATH environment variable
- * 3. Common installation directories (~/.cargo/bin, ~/.local/bin, /usr/local/bin)
+ * 2. Previously auto-downloaded binary in plugin data directory
+ * 3. PATH environment variable
+ * 4. Common installation directories (~/.cargo/bin, ~/.local/bin, /usr/local/bin)
+ * 5. Auto-download from GitHub Releases (via BinaryManager)
  */
 object CmodBinaryUtil {
 
@@ -22,86 +28,28 @@ object CmodBinaryUtil {
 
     private val BINARY_NAME = if (SystemInfo.isWindows) "cmod.exe" else "cmod"
 
-    private val COMMON_PATHS = listOf(
-        Paths.get(System.getProperty("user.home"), ".cargo", "bin", BINARY_NAME),
-        Paths.get(System.getProperty("user.home"), ".local", "bin", BINARY_NAME),
-        Paths.get("/usr", "local", "bin", BINARY_NAME),
-        Paths.get("/opt", "homebrew", "bin", BINARY_NAME),
-    )
-
     /**
-     * Finds the cmod binary, checking user settings first, then PATH, then
-     * common installation directories.
-     *
-     * @return The absolute path to the cmod binary, or null if not found.
-     */
-    fun findCmodBinary(): String? {
-        // Check user-configured path first
-        val settings = CmodSettingsState.getInstance()
-        if (settings.cmodBinaryPath.isNotBlank()) {
-            val configured = File(settings.cmodBinaryPath)
-            if (configured.exists() && configured.canExecute()) {
-                LOG.info("Using configured cmod binary: ${configured.absolutePath}")
-                return configured.absolutePath
-            }
-            LOG.warn("Configured cmod path does not exist or is not executable: ${settings.cmodBinaryPath}")
-        }
-
-        // Search PATH
-        val pathBinary = findOnPath()
-        if (pathBinary != null) {
-            LOG.info("Found cmod on PATH: $pathBinary")
-            return pathBinary
-        }
-
-        // Search common installation directories
-        for (path in COMMON_PATHS) {
-            if (Files.exists(path) && Files.isExecutable(path)) {
-                LOG.info("Found cmod at common path: $path")
-                return path.toAbsolutePath().toString()
-            }
-        }
-
-        LOG.warn("cmod binary not found")
-        return null
-    }
-
-    /**
-     * Searches the PATH environment variable for the cmod binary.
-     */
-    private fun findOnPath(): String? {
-        val pathEnv = System.getenv("PATH") ?: return null
-        val separator = if (SystemInfo.isWindows) ";" else ":"
-
-        for (dir in pathEnv.split(separator)) {
-            val candidate = Path.of(dir, BINARY_NAME)
-            if (Files.exists(candidate) && Files.isExecutable(candidate)) {
-                return candidate.toAbsolutePath().toString()
-            }
-        }
-        return null
-    }
-
-    /**
-     * Returns the cmod binary path for use in command execution.
-     * Falls back to "cmod" (relying on PATH resolution) if not found.
+     * Returns the cmod binary path, triggering auto-download if necessary.
+     * Falls back to "cmod" (relying on PATH resolution) if all else fails.
      */
     fun getCmodBinaryPath(): String {
-        return findCmodBinary() ?: BINARY_NAME
+        val binaryManager = BinaryManager.getInstance()
+        return binaryManager.ensureBinary() ?: BINARY_NAME
     }
 
     /**
      * Checks whether the cmod binary is available and executable.
      */
     fun isCmodAvailable(): Boolean {
-        return findCmodBinary() != null
+        val binaryManager = BinaryManager.getInstance()
+        return binaryManager.ensureBinary() != null
     }
 
     /**
      * Returns the cmod version string by running `cmod --version`.
      */
     fun getCmodVersion(): String? {
-        val binary = findCmodBinary() ?: return null
+        val binary = getCmodBinaryPath()
         return try {
             val process = ProcessBuilder(binary, "--version")
                 .redirectErrorStream(true)

--- a/editors/clion/src/main/kotlin/com/cmod/intellij/util/CmodBinaryUtil.kt
+++ b/editors/clion/src/main/kotlin/com/cmod/intellij/util/CmodBinaryUtil.kt
@@ -8,6 +8,7 @@ import java.io.File
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
+import java.util.concurrent.atomic.AtomicReference
 
 /**
  * Utility for locating the cmod binary on the system.
@@ -21,6 +22,13 @@ import java.nio.file.Paths
  * 3. PATH environment variable
  * 4. Common installation directories (~/.cargo/bin, ~/.local/bin, /usr/local/bin)
  * 5. Auto-download from GitHub Releases (via BinaryManager)
+ *
+ * ## Threading Notes
+ *
+ * Methods that call [BinaryManager.ensureBinary] (such as [getCmodBinaryPath],
+ * [findCmodBinary], and [isCmodAvailable]) may block with ProgressManager and
+ * should NOT be called from the EDT or during read actions. Use the non-blocking
+ * variants ([getCmodBinaryPathCached], [isCmodAvailableCached]) for those contexts.
  */
 object CmodBinaryUtil {
 
@@ -28,28 +36,85 @@ object CmodBinaryUtil {
 
     private val BINARY_NAME = if (SystemInfo.isWindows) "cmod.exe" else "cmod"
 
+    /** Cached resolved binary path after first successful resolution. */
+    private val cachedBinaryPath = AtomicReference<String?>(null)
+
     /**
      * Returns the cmod binary path, triggering auto-download if necessary.
      * Falls back to "cmod" (relying on PATH resolution) if all else fails.
+     *
+     * **Warning:** This method may block with ProgressManager. Do not call from
+     * EDT or read actions. Use [getCmodBinaryPathCached] for non-blocking access.
      */
     fun getCmodBinaryPath(): String {
         val binaryManager = BinaryManager.getInstance()
-        return binaryManager.ensureBinary() ?: BINARY_NAME
+        val path = binaryManager.ensureBinary() ?: BINARY_NAME
+        cachedBinaryPath.set(path)
+        return path
+    }
+
+    /**
+     * Returns the cached cmod binary path if previously resolved, or null.
+     * This method never triggers downloads and is safe to call from any thread.
+     */
+    fun getCmodBinaryPathCached(): String? {
+        return cachedBinaryPath.get()
+    }
+
+    /**
+     * Returns the cmod binary path if available, or null if not found.
+     * Triggers auto-download if necessary.
+     *
+     * **Warning:** This method may block with ProgressManager. Do not call from
+     * EDT or read actions.
+     */
+    fun findCmodBinary(): String? {
+        val path = BinaryManager.getInstance().ensureBinary()
+        if (path != null) {
+            cachedBinaryPath.set(path)
+        }
+        return path
     }
 
     /**
      * Checks whether the cmod binary is available and executable.
+     *
+     * **Warning:** This method may block with ProgressManager. Do not call from
+     * EDT or read actions. Use [isCmodAvailableCached] for non-blocking access.
      */
     fun isCmodAvailable(): Boolean {
         val binaryManager = BinaryManager.getInstance()
-        return binaryManager.ensureBinary() != null
+        val path = binaryManager.ensureBinary()
+        if (path != null) {
+            cachedBinaryPath.set(path)
+        }
+        return path != null
+    }
+
+    /**
+     * Returns whether a cmod binary path has been cached from a previous resolution.
+     * This method never triggers downloads and is safe to call from any thread.
+     *
+     * @param skipAutoDownload If true, only checks the cache. If false and cache
+     *        is empty, this still returns false (does not trigger download).
+     */
+    fun isCmodAvailableCached(skipAutoDownload: Boolean = true): Boolean {
+        return cachedBinaryPath.get() != null
+    }
+
+    /**
+     * Clears the cached binary path. Useful when settings change or binary
+     * is manually removed.
+     */
+    fun clearCache() {
+        cachedBinaryPath.set(null)
     }
 
     /**
      * Returns the cmod version string by running `cmod --version`.
      */
     fun getCmodVersion(): String? {
-        val binary = getCmodBinaryPath()
+        val binary = getCmodBinaryPathCached() ?: return null
         return try {
             val process = ProcessBuilder(binary, "--version")
                 .redirectErrorStream(true)

--- a/editors/clion/src/main/resources/META-INF/plugin.xml
+++ b/editors/clion/src/main/resources/META-INF/plugin.xml
@@ -83,6 +83,10 @@
         <applicationService
                 serviceImplementation="com.cmod.intellij.settings.CmodSettingsState"/>
 
+        <!-- Binary Manager (auto-download) -->
+        <applicationService
+                serviceImplementation="com.cmod.intellij.binary.BinaryManager"/>
+
         <!-- Notifications -->
         <notificationGroup id="cmod.notifications"
                            displayType="BALLOON"

--- a/editors/clion/src/main/resources/cmod.properties
+++ b/editors/clion/src/main/resources/cmod.properties
@@ -1,0 +1,1 @@
+cmod.binary.version=${cmodBinaryVersion}

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -28,6 +28,9 @@
     "type": "git",
     "url": "https://github.com/satishbabariya/cmod"
   },
+  "cmod": {
+    "binaryVersion": "0.1.0"
+  },
   "activationEvents": [
     "workspaceContains:cmod.toml",
     "onLanguage:cpp"
@@ -102,7 +105,7 @@
         "cmod.path": {
           "type": "string",
           "default": "",
-          "description": "Path to the cmod binary. Leave empty to use PATH."
+          "description": "Path to the cmod binary. Leave empty to auto-download or use PATH."
         },
         "cmod.lsp.enabled": {
           "type": "boolean",
@@ -239,6 +242,7 @@
     "@types/glob": "^8.1.0",
     "@vscode/test-electron": "^2.3.8",
     "@vscode/vsce": "^2.22.0",
+    "ovsx": "^0.8.0",
     "glob": "^10.3.10",
     "mocha": "^10.2.0",
     "ts-loader": "^9.5.1",

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -5,7 +5,7 @@ import { DependencyTreeProvider } from './views/dependencyTreeProvider';
 import { BuildStatusTreeProvider } from './views/buildStatusTreeProvider';
 import { CmodTaskProvider } from './tasks/cmodTaskProvider';
 import { BuildStatusItem } from './statusBar/buildStatusItem';
-import { getCmodBinaryPath } from './utils/cmodBinary';
+import { BinaryManager } from './utils/binaryManager';
 
 let lspClient: CmodLspClient | undefined;
 let dependencyTreeProvider: DependencyTreeProvider;
@@ -16,8 +16,19 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     const outputChannel = vscode.window.createOutputChannel('cmod');
     outputChannel.appendLine('cmod extension activating...');
 
-    // Verify cmod binary is available
-    const cmodPath = getCmodBinaryPath();
+    // Ensure cmod binary is available (downloads if needed)
+    const binaryManager = new BinaryManager(context, outputChannel);
+    let cmodPath: string;
+    try {
+        cmodPath = await binaryManager.ensureBinary();
+    } catch (err) {
+        outputChannel.appendLine(`Failed to obtain cmod binary: ${err}`);
+        vscode.window.showErrorMessage(
+            'cmod binary not available. Some features will be unavailable. ' +
+            'Install cmod manually or set cmod.path in settings.'
+        );
+        cmodPath = 'cmod'; // Fallback to PATH resolution
+    }
     outputChannel.appendLine(`Using cmod binary: ${cmodPath}`);
 
     // Create tree view providers

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -6,6 +6,7 @@ import { BuildStatusTreeProvider } from './views/buildStatusTreeProvider';
 import { CmodTaskProvider } from './tasks/cmodTaskProvider';
 import { BuildStatusItem } from './statusBar/buildStatusItem';
 import { BinaryManager } from './utils/binaryManager';
+import { setCachedBinaryPath } from './utils/cmodBinary';
 
 let lspClient: CmodLspClient | undefined;
 let dependencyTreeProvider: DependencyTreeProvider;
@@ -29,6 +30,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         );
         cmodPath = 'cmod'; // Fallback to PATH resolution
     }
+    setCachedBinaryPath(cmodPath);
     outputChannel.appendLine(`Using cmod binary: ${cmodPath}`);
 
     // Create tree view providers

--- a/editors/vscode/src/utils/binaryManager.ts
+++ b/editors/vscode/src/utils/binaryManager.ts
@@ -5,7 +5,7 @@ import * as https from 'https';
 import * as http from 'http';
 import * as crypto from 'crypto';
 import * as cp from 'child_process';
-import { createGunzip } from 'zlib';
+import { createGunzip, inflateRawSync } from 'zlib';
 
 /** The cmod version this extension expects. Kept in sync with package.json. */
 const EXPECTED_VERSION: string = require('../../package.json').cmod?.binaryVersion ?? require('../../package.json').version;
@@ -61,16 +61,20 @@ function getPlatformInfo(): PlatformInfo | undefined {
     return { target: entry.target, binaryName, archiveExt: entry.ext };
 }
 
+/** Default timeout in milliseconds for HTTP requests. */
+const REQUEST_TIMEOUT_MS = 30000;
+const SOCKET_TIMEOUT_MS = 15000;
+
 /**
  * Downloads a URL, following redirects, and returns the data as a Buffer.
  */
-function download(url: string, onProgress?: (percent: number) => void): Promise<Buffer> {
+function download(url: string, onProgress?: (percent: number) => void, timeoutMs: number = REQUEST_TIMEOUT_MS): Promise<Buffer> {
     return new Promise((resolve, reject) => {
         const get = url.startsWith('https') ? https.get : http.get;
-        get(url, { headers: { 'User-Agent': 'cmod-vscode' } }, (res) => {
-            // Follow redirects
+        const request = get(url, { headers: { 'User-Agent': 'cmod-vscode' } }, (res) => {
+            // Follow redirects (pass timeout to recursive call)
             if (res.statusCode && res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
-                download(res.headers.location, onProgress).then(resolve, reject);
+                download(res.headers.location, onProgress, timeoutMs).then(resolve, reject);
                 return;
             }
 
@@ -92,7 +96,24 @@ function download(url: string, onProgress?: (percent: number) => void): Promise<
             });
             res.on('end', () => resolve(Buffer.concat(chunks)));
             res.on('error', reject);
-        }).on('error', reject);
+        });
+
+        // Set request timeout
+        request.setTimeout(timeoutMs, () => {
+            request.destroy();
+            reject(new Error(`Download timeout after ${timeoutMs}ms for ${url}`));
+        });
+
+        // Set socket timeout when socket is assigned
+        request.on('socket', (socket) => {
+            socket.setTimeout(SOCKET_TIMEOUT_MS);
+            socket.on('timeout', () => {
+                request.destroy();
+                reject(new Error(`Socket timeout after ${SOCKET_TIMEOUT_MS}ms for ${url}`));
+            });
+        });
+
+        request.on('error', reject);
     });
 }
 
@@ -178,14 +199,34 @@ async function extractZip(archiveBuffer: Buffer, destDir: string, binaryName: st
             const lfhNameLen = archiveBuffer.readUInt16LE(localHeaderOffset + 26);
             const lfhExtraLen = archiveBuffer.readUInt16LE(localHeaderOffset + 28);
             const compressedSize = archiveBuffer.readUInt32LE(localHeaderOffset + 18);
+            const uncompressedSize = archiveBuffer.readUInt32LE(localHeaderOffset + 22);
             const dataOffset = localHeaderOffset + 30 + lfhNameLen + lfhExtraLen;
 
             const compressionMethod = archiveBuffer.readUInt16LE(localHeaderOffset + 8);
-            if (compressionMethod !== 0) {
-                throw new Error('Compressed zip entries not supported; expected stored (method 0)');
+            const compressedData = archiveBuffer.subarray(dataOffset, dataOffset + compressedSize);
+
+            let fileData: Buffer;
+            if (compressionMethod === 0) {
+                // Stored (no compression)
+                fileData = compressedData;
+            } else if (compressionMethod === 8) {
+                // DEFLATE compression
+                try {
+                    fileData = inflateRawSync(compressedData);
+                    if (fileData.length !== uncompressedSize) {
+                        throw new Error(
+                            `Decompressed size mismatch: expected ${uncompressedSize}, got ${fileData.length}`
+                        );
+                    }
+                } catch (err) {
+                    throw new Error(`Failed to decompress DEFLATE entry: ${err}`);
+                }
+            } else {
+                throw new Error(
+                    `Unsupported zip compression method ${compressionMethod}; only stored (0) and DEFLATE (8) are supported`
+                );
             }
 
-            const fileData = archiveBuffer.subarray(dataOffset, dataOffset + compressedSize);
             const destPath = path.join(destDir, binaryName);
             fs.writeFileSync(destPath, fileData);
             return;

--- a/editors/vscode/src/utils/binaryManager.ts
+++ b/editors/vscode/src/utils/binaryManager.ts
@@ -1,0 +1,410 @@
+import * as vscode from 'vscode';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as https from 'https';
+import * as http from 'http';
+import * as crypto from 'crypto';
+import * as cp from 'child_process';
+import { createGunzip } from 'zlib';
+
+/** The cmod version this extension expects. Kept in sync with package.json. */
+const EXPECTED_VERSION: string = require('../../package.json').cmod?.binaryVersion ?? require('../../package.json').version;
+
+const GITHUB_REPO = 'satishbabariya/cmod';
+
+interface PlatformInfo {
+    target: string;
+    binaryName: string;
+    archiveExt: string;
+}
+
+/**
+ * Resolves the current platform to a cmod release target triple.
+ */
+function getPlatformInfo(): PlatformInfo | undefined {
+    const platform = process.platform;
+    const arch = process.arch;
+    const binaryName = platform === 'win32' ? 'cmod.exe' : 'cmod';
+
+    const mapping: Record<string, Record<string, { target: string; ext: string }>> = {
+        linux: {
+            x64: { target: 'x86_64-unknown-linux-gnu', ext: 'tar.gz' },
+            arm64: { target: 'aarch64-unknown-linux-gnu', ext: 'tar.gz' },
+        },
+        darwin: {
+            x64: { target: 'x86_64-apple-darwin', ext: 'tar.gz' },
+            arm64: { target: 'aarch64-apple-darwin', ext: 'tar.gz' },
+        },
+        win32: {
+            x64: { target: 'x86_64-pc-windows-msvc', ext: 'zip' },
+            arm64: { target: 'aarch64-pc-windows-msvc', ext: 'zip' },
+        },
+    };
+
+    // Check for Alpine/musl
+    if (platform === 'linux' && arch === 'x64') {
+        try {
+            const lddOutput = cp.execSync('ldd --version 2>&1 || true', { encoding: 'utf-8' });
+            if (lddOutput.includes('musl')) {
+                return { target: 'x86_64-unknown-linux-musl', binaryName, archiveExt: 'tar.gz' };
+            }
+        } catch {
+            // Fall through to glibc default
+        }
+    }
+
+    const entry = mapping[platform]?.[arch];
+    if (!entry) {
+        return undefined;
+    }
+
+    return { target: entry.target, binaryName, archiveExt: entry.ext };
+}
+
+/**
+ * Downloads a URL, following redirects, and returns the data as a Buffer.
+ */
+function download(url: string, onProgress?: (percent: number) => void): Promise<Buffer> {
+    return new Promise((resolve, reject) => {
+        const get = url.startsWith('https') ? https.get : http.get;
+        get(url, { headers: { 'User-Agent': 'cmod-vscode' } }, (res) => {
+            // Follow redirects
+            if (res.statusCode && res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+                download(res.headers.location, onProgress).then(resolve, reject);
+                return;
+            }
+
+            if (res.statusCode !== 200) {
+                reject(new Error(`Download failed: HTTP ${res.statusCode} for ${url}`));
+                return;
+            }
+
+            const totalBytes = parseInt(res.headers['content-length'] || '0', 10);
+            const chunks: Buffer[] = [];
+            let receivedBytes = 0;
+
+            res.on('data', (chunk: Buffer) => {
+                chunks.push(chunk);
+                receivedBytes += chunk.length;
+                if (onProgress && totalBytes > 0) {
+                    onProgress(Math.round((receivedBytes / totalBytes) * 100));
+                }
+            });
+            res.on('end', () => resolve(Buffer.concat(chunks)));
+            res.on('error', reject);
+        }).on('error', reject);
+    });
+}
+
+/**
+ * Extracts cmod binary from a tar.gz archive buffer into the target directory.
+ */
+async function extractTarGz(archiveBuffer: Buffer, destDir: string, binaryName: string): Promise<void> {
+    // Simple tar extraction: gunzip then parse tar format
+    const gunzipped = await new Promise<Buffer>((resolve, reject) => {
+        const gunzip = createGunzip();
+        const chunks: Buffer[] = [];
+        gunzip.on('data', (chunk: Buffer) => chunks.push(chunk));
+        gunzip.on('end', () => resolve(Buffer.concat(chunks)));
+        gunzip.on('error', reject);
+        gunzip.end(archiveBuffer);
+    });
+
+    // Parse tar: find the binary entry
+    let offset = 0;
+    while (offset < gunzipped.length - 512) {
+        const header = gunzipped.subarray(offset, offset + 512);
+        // Check for empty block (end of archive)
+        if (header.every((b) => b === 0)) {
+            break;
+        }
+
+        const fileName = header.subarray(0, 100).toString('utf-8').replace(/\0/g, '').trim();
+        const sizeOctal = header.subarray(124, 136).toString('utf-8').replace(/\0/g, '').trim();
+        const fileSize = parseInt(sizeOctal, 8) || 0;
+
+        offset += 512; // Move past header
+
+        if (fileName === binaryName || fileName.endsWith('/' + binaryName)) {
+            const fileData = gunzipped.subarray(offset, offset + fileSize);
+            const destPath = path.join(destDir, binaryName);
+            fs.writeFileSync(destPath, fileData);
+            fs.chmodSync(destPath, 0o755);
+            return;
+        }
+
+        // Skip to next entry (aligned to 512 bytes)
+        offset += Math.ceil(fileSize / 512) * 512;
+    }
+
+    throw new Error(`Binary '${binaryName}' not found in archive`);
+}
+
+/**
+ * Extracts cmod.exe from a zip archive buffer into the target directory.
+ *
+ * Uses a minimal zip parser — no external dependencies needed.
+ */
+async function extractZip(archiveBuffer: Buffer, destDir: string, binaryName: string): Promise<void> {
+    // Find End of Central Directory record
+    let eocdOffset = -1;
+    for (let i = archiveBuffer.length - 22; i >= 0; i--) {
+        if (archiveBuffer.readUInt32LE(i) === 0x06054b50) {
+            eocdOffset = i;
+            break;
+        }
+    }
+    if (eocdOffset === -1) {
+        throw new Error('Invalid zip archive: EOCD not found');
+    }
+
+    const centralDirOffset = archiveBuffer.readUInt32LE(eocdOffset + 16);
+    const centralDirEntries = archiveBuffer.readUInt16LE(eocdOffset + 10);
+
+    let cdOffset = centralDirOffset;
+    for (let i = 0; i < centralDirEntries; i++) {
+        if (archiveBuffer.readUInt32LE(cdOffset) !== 0x02014b50) {
+            break;
+        }
+
+        const fileNameLen = archiveBuffer.readUInt16LE(cdOffset + 28);
+        const extraLen = archiveBuffer.readUInt16LE(cdOffset + 30);
+        const commentLen = archiveBuffer.readUInt16LE(cdOffset + 32);
+        const localHeaderOffset = archiveBuffer.readUInt32LE(cdOffset + 42);
+        const fileName = archiveBuffer.subarray(cdOffset + 46, cdOffset + 46 + fileNameLen).toString('utf-8');
+
+        if (fileName === binaryName || fileName.endsWith('/' + binaryName)) {
+            // Read from local file header
+            const lfhNameLen = archiveBuffer.readUInt16LE(localHeaderOffset + 26);
+            const lfhExtraLen = archiveBuffer.readUInt16LE(localHeaderOffset + 28);
+            const compressedSize = archiveBuffer.readUInt32LE(localHeaderOffset + 18);
+            const dataOffset = localHeaderOffset + 30 + lfhNameLen + lfhExtraLen;
+
+            const compressionMethod = archiveBuffer.readUInt16LE(localHeaderOffset + 8);
+            if (compressionMethod !== 0) {
+                throw new Error('Compressed zip entries not supported; expected stored (method 0)');
+            }
+
+            const fileData = archiveBuffer.subarray(dataOffset, dataOffset + compressedSize);
+            const destPath = path.join(destDir, binaryName);
+            fs.writeFileSync(destPath, fileData);
+            return;
+        }
+
+        cdOffset += 46 + fileNameLen + extraLen + commentLen;
+    }
+
+    throw new Error(`Binary '${binaryName}' not found in archive`);
+}
+
+/**
+ * Manages downloading and verifying the cmod binary.
+ */
+export class BinaryManager {
+    private readonly binDir: string;
+    private readonly outputChannel: vscode.OutputChannel;
+
+    constructor(context: vscode.ExtensionContext, outputChannel: vscode.OutputChannel) {
+        this.binDir = path.join(context.globalStorageUri.fsPath, 'bin');
+        this.outputChannel = outputChannel;
+    }
+
+    /**
+     * Returns the path to the cmod binary, downloading it if necessary.
+     *
+     * Resolution order:
+     * 1. User-configured `cmod.path` setting
+     * 2. Bundled binary (platform-specific VSIX)
+     * 3. Previously downloaded binary in global storage
+     * 4. `cmod` on system PATH
+     * 5. Auto-download from GitHub Releases
+     */
+    async ensureBinary(): Promise<string> {
+        // 1. User-configured path
+        const config = vscode.workspace.getConfiguration('cmod');
+        const configuredPath = config.get<string>('path', '').trim();
+        if (configuredPath) {
+            const resolved = this.resolveHome(configuredPath);
+            if (fs.existsSync(resolved)) {
+                this.outputChannel.appendLine(`Using configured cmod binary: ${resolved}`);
+                return resolved;
+            }
+            this.outputChannel.appendLine(`Configured path not found: ${resolved}, trying other sources.`);
+        }
+
+        const platformInfo = getPlatformInfo();
+        const binaryName = platformInfo?.binaryName ?? (process.platform === 'win32' ? 'cmod.exe' : 'cmod');
+
+        // 2. Bundled binary (shipped inside the VSIX for platform-specific packages)
+        const bundledPath = path.join(__dirname, '..', 'bin', binaryName);
+        if (fs.existsSync(bundledPath)) {
+            this.outputChannel.appendLine(`Using bundled cmod binary: ${bundledPath}`);
+            return bundledPath;
+        }
+
+        // 3. Previously downloaded binary
+        const managedPath = path.join(this.binDir, binaryName);
+        if (fs.existsSync(managedPath)) {
+            const version = this.getVersion(managedPath);
+            if (version && version.includes(EXPECTED_VERSION)) {
+                this.outputChannel.appendLine(`Using managed cmod binary: ${managedPath} (${version})`);
+                return managedPath;
+            }
+            this.outputChannel.appendLine(`Managed binary version mismatch (got ${version}, want ${EXPECTED_VERSION}), will re-download.`);
+        }
+
+        // 4. System PATH
+        const systemPath = this.findOnPath(binaryName);
+        if (systemPath) {
+            const version = this.getVersion(systemPath);
+            if (version && version.includes(EXPECTED_VERSION)) {
+                this.outputChannel.appendLine(`Using system cmod binary: ${systemPath} (${version})`);
+                return systemPath;
+            }
+            // System binary exists but wrong version — still try auto-download
+            this.outputChannel.appendLine(`System cmod version mismatch (got ${version}, want ${EXPECTED_VERSION}).`);
+        }
+
+        // 5. Auto-download
+        if (!platformInfo) {
+            const msg = `Unsupported platform: ${process.platform}/${process.arch}. Please install cmod manually and set cmod.path.`;
+            vscode.window.showErrorMessage(msg);
+            // Fall back to system PATH binary or bare name
+            return systemPath ?? 'cmod';
+        }
+
+        return this.downloadBinary(platformInfo);
+    }
+
+    private async downloadBinary(platformInfo: PlatformInfo): Promise<string> {
+        const version = `v${EXPECTED_VERSION}`;
+        const archiveName = `cmod-${version}-${platformInfo.target}.${platformInfo.archiveExt}`;
+        const archiveUrl = `https://github.com/${GITHUB_REPO}/releases/download/${version}/${archiveName}`;
+        const checksumsUrl = `https://github.com/${GITHUB_REPO}/releases/download/${version}/checksums-${version}.sha256`;
+
+        const destPath = path.join(this.binDir, platformInfo.binaryName);
+
+        return vscode.window.withProgress(
+            {
+                location: vscode.ProgressLocation.Notification,
+                title: 'cmod',
+                cancellable: true,
+            },
+            async (progress, token) => {
+                progress.report({ message: `Downloading cmod ${version}...` });
+                this.outputChannel.appendLine(`Downloading ${archiveUrl}`);
+
+                if (token.isCancellationRequested) {
+                    throw new Error('Download cancelled');
+                }
+
+                // Download archive
+                const archiveBuffer = await download(archiveUrl, (percent) => {
+                    progress.report({ message: `Downloading cmod ${version}... ${percent}%`, increment: 0 });
+                });
+
+                if (token.isCancellationRequested) {
+                    throw new Error('Download cancelled');
+                }
+
+                // Download and verify checksum
+                progress.report({ message: 'Verifying checksum...' });
+                try {
+                    const checksumsData = await download(checksumsUrl);
+                    const checksumsText = checksumsData.toString('utf-8');
+                    const expectedHash = this.parseChecksumForFile(checksumsText, archiveName);
+
+                    if (expectedHash) {
+                        const actualHash = crypto.createHash('sha256').update(archiveBuffer).digest('hex');
+                        if (actualHash !== expectedHash) {
+                            throw new Error(
+                                `Checksum mismatch for ${archiveName}:\n  expected: ${expectedHash}\n  actual:   ${actualHash}`
+                            );
+                        }
+                        this.outputChannel.appendLine(`Checksum verified: ${actualHash}`);
+                    } else {
+                        this.outputChannel.appendLine(`Warning: no checksum found for ${archiveName}, skipping verification.`);
+                    }
+                } catch (err) {
+                    if (err instanceof Error && err.message.includes('Checksum mismatch')) {
+                        throw err;
+                    }
+                    this.outputChannel.appendLine(`Warning: could not verify checksum: ${err}`);
+                }
+
+                // Extract binary
+                progress.report({ message: 'Extracting binary...' });
+                fs.mkdirSync(this.binDir, { recursive: true });
+
+                if (platformInfo.archiveExt === 'tar.gz') {
+                    await extractTarGz(archiveBuffer, this.binDir, platformInfo.binaryName);
+                } else {
+                    await extractZip(archiveBuffer, this.binDir, platformInfo.binaryName);
+                }
+
+                this.outputChannel.appendLine(`cmod binary installed to ${destPath}`);
+                vscode.window.showInformationMessage(`cmod ${version} downloaded successfully.`);
+                return destPath;
+            }
+        );
+    }
+
+    private parseChecksumForFile(checksumsText: string, fileName: string): string | undefined {
+        for (const line of checksumsText.split('\n')) {
+            const trimmed = line.trim();
+            if (!trimmed) {
+                continue;
+            }
+            // Format: "hash  filename" or "hash *filename"
+            const parts = trimmed.split(/\s+/);
+            if (parts.length >= 2) {
+                const hash = parts[0];
+                const name = parts[parts.length - 1].replace(/^\*/, '');
+                if (name === fileName || name.endsWith('/' + fileName)) {
+                    return hash;
+                }
+            }
+        }
+        return undefined;
+    }
+
+    private getVersion(binaryPath: string): string | undefined {
+        try {
+            const result = cp.execSync(`"${binaryPath}" --version`, {
+                timeout: 5000,
+                encoding: 'utf-8',
+                stdio: ['pipe', 'pipe', 'pipe'],
+            });
+            return result.trim();
+        } catch {
+            return undefined;
+        }
+    }
+
+    private findOnPath(binaryName: string): string | undefined {
+        const pathEnv = process.env.PATH || '';
+        const separator = process.platform === 'win32' ? ';' : ':';
+        const extensions = process.platform === 'win32' ? ['.exe', '.cmd', '.bat', ''] : [''];
+
+        for (const dir of pathEnv.split(separator)) {
+            for (const ext of extensions) {
+                const fullPath = path.join(dir, binaryName + (ext && !binaryName.endsWith(ext) ? ext : ''));
+                try {
+                    fs.accessSync(fullPath, fs.constants.X_OK);
+                    return fullPath;
+                } catch {
+                    // continue
+                }
+            }
+        }
+        return undefined;
+    }
+
+    private resolveHome(filepath: string): string {
+        if (filepath.startsWith('~/') || filepath === '~') {
+            const home = process.env.HOME || process.env.USERPROFILE || '';
+            return path.join(home, filepath.slice(2));
+        }
+        return filepath;
+    }
+}

--- a/editors/vscode/src/utils/cmodBinary.ts
+++ b/editors/vscode/src/utils/cmodBinary.ts
@@ -3,12 +3,24 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as cp from 'child_process';
 
+/** Cached binary path set by BinaryManager during activation. */
+let cachedBinaryPath: string | undefined;
+
+/**
+ * Set the cached cmod binary path. Called by extension activation after
+ * BinaryManager resolves/downloads the binary.
+ */
+export function setCachedBinaryPath(binaryPath: string): void {
+    cachedBinaryPath = binaryPath;
+}
+
 /**
  * Get the path to the cmod binary.
  *
  * Resolution order:
  * 1. cmod.path setting in VS Code configuration
- * 2. "cmod" found on the system PATH
+ * 2. Cached path from BinaryManager (set during activation)
+ * 3. "cmod" found on the system PATH
  *
  * Returns "cmod" as a fallback (relying on PATH resolution at runtime).
  */
@@ -26,6 +38,11 @@ export function getCmodBinaryPath(): string {
         vscode.window.showWarningMessage(
             `cmod binary not found at configured path: ${resolved}. Falling back to PATH.`
         );
+    }
+
+    // Use cached path from BinaryManager if available
+    if (cachedBinaryPath && fs.existsSync(cachedBinaryPath)) {
+        return cachedBinaryPath;
     }
 
     // Try to find cmod on PATH


### PR DESCRIPTION
Covers release pipelines for 7 platform targets (adding Windows x86_64,
Windows aarch64, Linux musl), VS Code extension publishing (Marketplace,
Open VSX, GitHub Releases), CLion plugin publishing (JetBrains Marketplace,
GitHub Releases), and auto-download mechanism for editor extensions.

https://claude.ai/code/session_01QkYqfPkgYD2vrevB7Z2Cbk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Auto-download, verification, extraction and management of the cmod binary in CLion and VS Code with platform-aware handling, progress UI, notifications, caching and version checks
  * Automated release pipelines for CLion and VS Code: multi-platform packaging, checksums, signing, and publishing to marketplaces and GitHub Releases

* **Documentation**
  * Added end-to-end binary publishing and release workflow plan

* **Configuration**
  * Exposed cmod binary version, updated path description to allow auto-download, and added allowUnverifiedBinaries setting
<!-- end of auto-generated comment: release notes by coderabbit.ai -->