### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/satishbabariya/cmod/security/code-scanning/5](https://github.com/satishbabariya/cmod/security/code-scanning/5)

In general, fix this by explicitly specifying restricted `GITHUB_TOKEN` permissions in the workflow, either at the workflow root (applies to all jobs) or per-job. Since none of the jobs need to modify repository contents, issues, or pull requests, we can safely restrict to `contents: read`, which matches CodeQL’s suggested minimal starting point and preserves existing behavior.

The best fix here is to add a single root-level `permissions:` block just under the `name: CI` (and before `on:`) in `.github/workflows/ci.yml`, with `contents: read`. This will apply to all jobs (`fmt`, `clippy`, `test`, `e2e`, `msrv`) without changing their steps or behavior, and satisfies the analyzer’s requirement. No additional imports or methods are needed; this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow configuration to enforce stricter security permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->