### PR TITLE
fix: resolve concurrency issues in worker task handling and improve error reporting

### DIFF
--- a/crates/cmod-build/src/distributed.rs
+++ b/crates/cmod-build/src/distributed.rs
@@ -402,20 +402,19 @@ impl WorkerPool {
 
             match self.send_task(&endpoint, &task) {
                 Ok(result) => {
-                    // Store the result so collect_result() can return it.
+                    // Store the result and record the task->worker mapping atomically.
+                    // Acquire locks in the same order used by collect_result /
+                    // try_collect_result (results first, then task_workers) to avoid
+                    // lock-order inversions.
                     {
                         let mut results = self
                             .results
                             .lock()
                             .map_err(|_| CmodError::Other("failed to lock results".to_string()))?;
-                        results.insert(task_id.clone(), result);
-                    }
-
-                    // Record which worker owns this task for slot release.
-                    {
                         let mut tw = self.task_workers.lock().map_err(|_| {
                             CmodError::Other("failed to lock task workers".to_string())
                         })?;
+                        results.insert(task_id.clone(), result);
                         tw.insert(task_id.clone(), worker_id.to_string());
                     }
 

--- a/crates/cmod-build/src/runner.rs
+++ b/crates/cmod-build/src/runner.rs
@@ -988,6 +988,7 @@ impl BuildRunner {
                 let node_timings = Arc::clone(&node_timings);
 
                 scope.spawn(move || {
+                    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                     loop {
                         // Check if all work is done
                         if completed.load(Ordering::SeqCst) >= total {
@@ -1092,6 +1093,23 @@ impl BuildRunner {
                         let _ = c;
                     }
                     drop(work_tx);
+                    })); // end catch_unwind closure
+                    if let Err(panic_payload) = result {
+                        let msg = panic_payload
+                            .downcast_ref::<&str>()
+                            .map(|s| s.to_string())
+                            .or_else(|| {
+                                panic_payload
+                                    .downcast_ref::<String>()
+                                    .map(|s| s.clone())
+                            })
+                            .unwrap_or_else(|| "worker thread panicked".to_string());
+                        if let Ok(mut guard) = errors.lock() {
+                            guard.push(CmodError::BuildFailed {
+                                reason: format!("worker panicked: {}", msg),
+                            });
+                        }
+                    }
                 });
             }
             // Drop sender on main thread so workers can detect disconnection

--- a/crates/cmod-cache/src/cache.rs
+++ b/crates/cmod-cache/src/cache.rs
@@ -11,9 +11,25 @@ use crate::key::{hash_file, CacheKey};
 /// Validate that a string is safe to use as a path component.
 ///
 /// Rejects path traversal sequences and other dangerous patterns.
+/// Rules mirror those in `cmod_core::types` path validation:
+/// - Must be non-empty
+/// - Must not be `"."` or `".."`
+/// - Must not start or end with `'.'`
+/// - Must not contain path separators, control characters, or `".."`
 fn is_safe_path_component(s: &str) -> bool {
     // Reject empty strings
     if s.is_empty() {
+        return false;
+    }
+
+    // Reject the special directory entries "." and ".."
+    if s == "." || s == ".." {
+        return false;
+    }
+
+    // Reject components starting or ending with '.' (hidden files, Windows
+    // collisions like "foo.", and relative-path building via e.g. ".hidden")
+    if s.starts_with('.') || s.ends_with('.') {
         return false;
     }
 
@@ -24,11 +40,6 @@ fn is_safe_path_component(s: &str) -> bool {
 
     // Reject path separators
     if s.contains('/') || s.contains('\\') {
-        return false;
-    }
-
-    // Reject absolute path indicators
-    if s.starts_with('/') || s.starts_with('\\') {
         return false;
     }
 
@@ -143,7 +154,10 @@ impl ArtifactCache {
 
     /// Check if a cache entry exists and is valid.
     pub fn has(&self, module_id: &str, key: &CacheKey) -> bool {
-        let dir = self.entry_dir(module_id, key);
+        let dir = match self.validated_entry_dir(module_id, key) {
+            Ok(d) => d,
+            Err(_) => return false,
+        };
         dir.join("metadata.json").exists()
     }
 
@@ -243,7 +257,7 @@ impl ArtifactCache {
         module_id: &str,
         key: &CacheKey,
     ) -> Result<ArtifactMetadata, CmodError> {
-        let path = self.entry_dir(module_id, key).join("metadata.json");
+        let path = self.validated_entry_dir(module_id, key)?.join("metadata.json");
         let content = fs::read_to_string(&path).map_err(|_| CmodError::CacheError {
             reason: format!("cache metadata not found for {} at key {}", module_id, key),
         })?;
@@ -254,7 +268,7 @@ impl ArtifactCache {
 
     /// Remove a single cache entry.
     pub fn evict(&self, module_id: &str, key: &CacheKey) -> Result<(), CmodError> {
-        let dir = self.entry_dir(module_id, key);
+        let dir = self.validated_entry_dir(module_id, key)?;
         if dir.exists() {
             fs::remove_dir_all(&dir)?;
         }
@@ -263,6 +277,15 @@ impl ArtifactCache {
 
     /// Remove all cache entries for a module.
     pub fn evict_module(&self, module_id: &str) -> Result<(), CmodError> {
+        // Validate module_id segments before joining into a path.
+        if !module_id.split('.').all(is_safe_path_component) {
+            return Err(CmodError::CacheError {
+                reason: format!(
+                    "invalid module_id: contains path traversal or unsafe characters: {}",
+                    module_id
+                ),
+            });
+        }
         let dir = self.root.join(module_id);
         if dir.exists() {
             fs::remove_dir_all(&dir)?;
@@ -365,8 +388,18 @@ impl ArtifactCache {
         key: &CacheKey,
         artifact_name: &str,
     ) -> Result<bool, CmodError> {
+        // Validate artifact name to prevent path traversal
+        if !is_safe_path_component(artifact_name) {
+            return Err(CmodError::CacheError {
+                reason: format!(
+                    "invalid artifact name: contains path traversal or unsafe characters: {}",
+                    artifact_name
+                ),
+            });
+        }
+
         let metadata = self.get_metadata(module_id, key)?;
-        let artifact_path = self.entry_dir(module_id, key).join(artifact_name);
+        let artifact_path = self.validated_entry_dir(module_id, key)?.join(artifact_name);
 
         if !artifact_path.exists() {
             return Ok(false);
@@ -519,7 +552,19 @@ impl ArtifactCache {
         metadata: &ArtifactMetadata,
         artifact_files: &[(&str, &Path)],
     ) -> Result<(), CmodError> {
-        let dir = self.entry_dir(module_id, key);
+        // Validate all artifact names before proceeding
+        for (name, _) in artifact_files {
+            if !is_safe_path_component(name) {
+                return Err(CmodError::CacheError {
+                    reason: format!(
+                        "invalid artifact name: contains path traversal or unsafe characters: {}",
+                        name
+                    ),
+                });
+            }
+        }
+
+        let dir = self.validated_entry_dir(module_id, key)?;
         fs::create_dir_all(&dir)?;
 
         // Write metadata
@@ -548,7 +593,17 @@ impl ArtifactCache {
         artifact_name: &str,
         dest: &Path,
     ) -> Result<bool, CmodError> {
-        let entry_dir = self.entry_dir(module_id, key);
+        // Validate artifact name to prevent path traversal
+        if !is_safe_path_component(artifact_name) {
+            return Err(CmodError::CacheError {
+                reason: format!(
+                    "invalid artifact name: contains path traversal or unsafe characters: {}",
+                    artifact_name
+                ),
+            });
+        }
+
+        let entry_dir = self.validated_entry_dir(module_id, key)?;
 
         // Try compressed version first
         let compressed_path = entry_dir.join(format!("{}.zst", artifact_name));
@@ -577,7 +632,7 @@ impl ArtifactCache {
 
     /// Inspect a specific cache entry and return its metadata plus file info.
     pub fn inspect(&self, module_id: &str, key: &CacheKey) -> Result<CacheEntryInfo, CmodError> {
-        let dir = self.entry_dir(module_id, key);
+        let dir = self.validated_entry_dir(module_id, key)?;
         if !dir.exists() {
             return Err(CmodError::CacheError {
                 reason: format!("cache entry not found: {}/{}", module_id, key),

--- a/crates/cmod-cli/src/commands/vendor.rs
+++ b/crates/cmod-cli/src/commands/vendor.rs
@@ -24,8 +24,9 @@ fn is_safe_package_name(name: &str) -> bool {
         return false;
     }
 
-    // Reject strings that start with a dot (hidden files, traversal)
-    if name.starts_with('.') {
+    // Reject strings that start or end with a dot (hidden files, traversal,
+    // and Windows path collisions like "foo.")
+    if name.starts_with('.') || name.ends_with('.') {
         return false;
     }
 

--- a/crates/cmod-cli/tests/real_projects.rs
+++ b/crates/cmod-cli/tests/real_projects.rs
@@ -1848,9 +1848,14 @@ fn test_real_git_update_resolves_new_tags() {
     assert!(output.status.success());
 
     let dep_url = local_file_url(&dep_dir);
-    run_cmod_with_local_git(
+    let add_output = run_cmod_with_local_git(
         &proj_dir,
         &["add", "updlib", "--git", &dep_url, "--untrusted"],
+    );
+    assert!(
+        add_output.status.success(),
+        "add updlib failed: {}",
+        stderr(&add_output)
     );
     let output = run_cmod_with_local_git(&proj_dir, &["resolve", "--untrusted"]);
     assert!(

--- a/crates/cmod-core/src/manifest.rs
+++ b/crates/cmod-core/src/manifest.rs
@@ -637,8 +637,8 @@ impl Manifest {
     ///
     /// Optimized to avoid unnecessary cloning when there are no target-specific deps.
     pub fn effective_dependencies(&self, target_triple: &str) -> BTreeMap<String, Dependency> {
-        // Fast path: if no target-specific deps, return a reference-based view
-        // or clone only once at the end
+        // Fast path: if there are no target-specific deps, no merging is needed —
+        // clone dependencies once and return immediately without iterating targets.
         if self.target.is_empty() {
             return self.dependencies.clone();
         }

--- a/crates/cmod-resolver/src/git.rs
+++ b/crates/cmod-resolver/src/git.rs
@@ -218,12 +218,13 @@ pub fn commit_date(repo: &Repository, oid: Oid) -> Result<String, CmodError> {
             // Log warning about invalid timestamp - use eprintln for now
             // In production, this should use a proper logging framework
             eprintln!(
-                "warning: commit {} has invalid timestamp ({}), using current date",
+                "warning: commit {} has invalid timestamp ({}), using sentinel date",
                 short_hash(&oid),
                 secs
             );
-            // Fall back to current time instead of UNIX_EPOCH to avoid cache collisions
-            chrono::Utc::now()
+            // Fall back to a fixed sentinel (UNIX_EPOCH) so pseudo-versions are
+            // deterministic and reproducible instead of varying by wall-clock time.
+            chrono::DateTime::from_timestamp(0, 0).expect("UNIX_EPOCH is always valid")
         }
     };
     Ok(dt.format("%Y%m%d").to_string())


### PR DESCRIPTION
This pull request introduces improvements to path validation and error handling across the cache and build runner modules, focusing on preventing unsafe file operations and improving robustness against panics. The most important changes are grouped below by theme.

**Cache Path Validation and Safety Enhancements:**

* Strengthened path validation in `crates/cmod-cache/src/cache.rs` by updating `is_safe_path_component` to reject `"."`, `".."`, components starting or ending with a dot, and other unsafe patterns, mirroring rules from `cmod_core::types`.
* Replaced usages of `entry_dir` with `validated_entry_dir` throughout `ArtifactCache` methods, ensuring all cache operations validate module IDs and artifact names before constructing paths. This prevents path traversal and unsafe file access. [[1]](diffhunk://#diff-9cf27502f35698873dd260955c4542564260fc07dbaff0849f615d1d8bfafe08L146-R160) [[2]](diffhunk://#diff-9cf27502f35698873dd260955c4542564260fc07dbaff0849f615d1d8bfafe08L246-R260) [[3]](diffhunk://#diff-9cf27502f35698873dd260955c4542564260fc07dbaff0849f615d1d8bfafe08L257-R271) [[4]](diffhunk://#diff-9cf27502f35698873dd260955c4542564260fc07dbaff0849f615d1d8bfafe08R280-R288) [[5]](diffhunk://#diff-9cf27502f35698873dd260955c4542564260fc07dbaff0849f615d1d8bfafe08R391-R402) [[6]](diffhunk://#diff-9cf27502f35698873dd260955c4542564260fc07dbaff0849f615d1d8bfafe08L522-R567) [[7]](diffhunk://#diff-9cf27502f35698873dd260955c4542564260fc07dbaff0849f615d1d8bfafe08L551-R606) [[8]](diffhunk://#diff-9cf27502f35698873dd260955c4542564260fc07dbaff0849f615d1d8bfafe08L580-R635)
* Added explicit validation for artifact names and module IDs before performing cache operations, returning errors for unsafe inputs. [[1]](diffhunk://#diff-9cf27502f35698873dd260955c4542564260fc07dbaff0849f615d1d8bfafe08R391-R402) [[2]](diffhunk://#diff-9cf27502f35698873dd260955c4542564260fc07dbaff0849f615d1d8bfafe08L522-R567) [[3]](diffhunk://#diff-9cf27502f35698873dd260955c4542564260fc07dbaff0849f615d1d8bfafe08L551-R606) [[4]](diffhunk://#diff-9cf27502f35698873dd260955c4542564260fc07dbaff0849f615d1d8bfafe08R280-R288)

**Build Runner Robustness:**

* Wrapped worker thread execution in `std::panic::catch_unwind` inside `BuildRunner` to catch panics and record them as build errors, preventing silent failures and improving error visibility. [[1]](diffhunk://#diff-0af5d90b3160ba73067e2d5b8e4815bca4259f96c639cf63dadfe108facfd114R991) [[2]](diffhunk://#diff-0af5d90b3160ba73067e2d5b8e4815bca4259f96c639cf63dadfe108facfd114R1096-R1112)

**Miscellaneous Improvements:**

* Updated path validation logic in `crates/cmod-cli/src/commands/vendor.rs` to reject package names that start or end with a dot, enhancing safety and consistency.
* Improved test reliability in `crates/cmod-cli/tests/real_projects.rs` by asserting the success of the `add` command and providing error output for easier debugging.
* Clarified fast-path logic in `Manifest::effective_dependencies` to avoid unnecessary iteration when there are no target-specific dependencies.
* Changed fallback behavior for invalid commit timestamps in `crates/cmod-resolver/src/git.rs` to use a fixed sentinel date (`UNIX_EPOCH`) for deterministic pseudo-versions.
* Fixed atomicity and lock-order in `WorkerPool::send_task` to prevent lock-order inversions, improving thread safety.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced input validation across cache operations for improved security.
  * Improved panic handling in worker threads for better reliability.
  * Fixed non-deterministic timestamp behavior in Git operations for consistency.
  * Strengthened package name validation to reject additional invalid patterns.

* **Tests**
  * Added validation checks to real-project integration tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->