### PR TITLE
Release v0.1.0-alpha.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0-alpha.2] - 2026-04-21
+
+### Fixed
+
+- **`cmod vendor` accepts Git-URL dep names** — the path-safety check previously rejected every dep whose name contained `/` (i.e. `github.com/owner/repo` — the whole Git-URL convention), blocking every offline workflow. Vendor now encodes names to the same underscore-separated on-disk form the resolver already uses (`vendor/github.com_owner_repo/`) while preserving the Git-URL key in `vendor/config.toml`. (#31, BUG-01)
+- **`cmod verify --signatures` looks up repos at the right path** — previously path-joined raw package names, hitting `build/deps/github.com/owner/repo` instead of the actual `build/deps/github.com_owner_repo`. Now shares `sanitize_package_name_for_path` with the resolver and vendor. (#31, BUG-02)
+- **`cmod workspace add <dir>` registers existing member directories** — adding a pre-existing dir with its own `cmod.toml` now registers it instead of rejecting with "already exists". Missing dirs are still scaffolded; orphan dirs without a manifest are rejected with a clear error; duplicate members are caught up-front. (#31, BUG-03)
+- **`cmod run --release` locates the release binary** — `run` was resolving the debug path even when building with `--release`. Now computes the profile-specific directory directly from the flag. (#31, BUG-04)
+- **Release builds rebuild path deps in release mode** — `cmod build --release` previously linked `libs/<dep>/build/debug/libX.a` into the release binary, mixing profiles. Profile, locked, offline, and target settings now propagate from the parent's `Config` into each path-dep sub-build. **First release build after upgrade will recompile path deps from scratch.** (#31, BUG-05)
+
+### Changed
+
+- **Cache keys include the compiler version.** `ClangBackend::detect_version()` parses `clang --version` once per build; `BuildRunner` memoizes and feeds it into both `CacheKey::compute` and `ArtifactMetadata`. PCMs produced by different Clang majors no longer collide in the local cache — fixes spurious "module file uses an older format" errors after a Clang upgrade. **One-time cache miss on first build after upgrade** (expected and harmless; `cmod cache clean` optional). (#31)
+- **Integration test harness** `example_projects::copy_dir_recursive` now skips `build/`, `target/`, `.cache`, `.git`, `vendor`, `compile_commands.json`, and `CMakeLists.txt` so the suite is stable regardless of the developer's local build artefacts. (#31, BUG-07)
+
+### Added
+
+- **`cmod cache push/pull --remote <URL>`** — per-invocation override for the remote cache endpoint, complementing the manifest-level `[cache].shared_url`. Useful for CI and ad-hoc inspection. (#31, BUG-06)
+- **`cmod_core::types::is_acceptable_package_name` / `sanitize_package_name_for_path`** — shared helpers so resolver, vendor, verify, and policy agree on on-disk dep directory naming. (#31)
+
+### Dependencies
+
+- Bump `rustls-webpki` in the cargo group (Dependabot #29).
+
+### Internal
+
+- clippy 1.95 clean: collapse a nested `if` into a match guard in `cmod-lsp::CodeActionHandler`. (#32)
+
 ## [0.1.0-alpha.1] - 2026-03-14
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,7 +186,7 @@ checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "cmod-build"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.2"
 dependencies = [
  "anyhow",
  "cmod-cache",
@@ -205,7 +205,7 @@ dependencies = [
 
 [[package]]
 name = "cmod-cache"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -224,7 +224,7 @@ dependencies = [
 
 [[package]]
 name = "cmod-cli"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -251,7 +251,7 @@ dependencies = [
 
 [[package]]
 name = "cmod-core"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.2"
 dependencies = [
  "anstream",
  "anstyle",
@@ -270,7 +270,7 @@ dependencies = [
 
 [[package]]
 name = "cmod-lsp"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.2"
 dependencies = [
  "anyhow",
  "cmod-build",
@@ -284,7 +284,7 @@ dependencies = [
 
 [[package]]
 name = "cmod-resolver"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -303,7 +303,7 @@ dependencies = [
 
 [[package]]
 name = "cmod-security"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.2"
 dependencies = [
  "cmod-cache",
  "cmod-core",
@@ -321,7 +321,7 @@ dependencies = [
 
 [[package]]
 name = "cmod-workspace"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.2"
 dependencies = [
  "anyhow",
  "cmod-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.2"
 edition = "2021"
 rust-version = "1.74"
 authors = ["Satish Babariya"]

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,86 @@
+# cmod v0.1.0-alpha.2
+
+**Audit-cleanup release.** Fixes 7 bugs surfaced by a full command-surface test pass (documented in `docs/TEST_REPORT.md`), hardens the cache key against Clang upgrades, and adds an ad-hoc `--remote` flag to `cmod cache push/pull`. No new features of scale — this is a stability release over `v0.1.0-alpha.1`.
+
+---
+
+## Upgrade notes
+
+Two behaviour changes to be aware of — both are expected, neither requires user action:
+
+- **One-time cache miss on first build.** `ClangBackend::detect_version()` now feeds `clang --version` into the cache key, so existing cache entries are orphaned. The next `cmod build` will rebuild from scratch once, then hit the cache as normal. Run `cmod cache clean` if you want to reclaim the orphaned space immediately.
+- **First release build after upgrade recompiles path dependencies.** `cmod build --release` now correctly rebuilds path deps under the release profile (previously it linked the debug artefacts). If your project has many path deps, that first release build will be slower; subsequent builds are cached.
+
+Nothing else in the manifest, lockfile, or CLI surface changed incompatibly.
+
+## Bug fixes
+
+| Bug | Severity | What changed |
+|---|---|---|
+| **BUG-01** | high | `cmod vendor` now encodes Git-URL dep names into filesystem-safe dirs (`vendor/github.com_fmtlib_fmt/`) instead of rejecting them as "path traversal" |
+| **BUG-02** | high | `cmod verify --signatures` now opens repos at the sanitized path the resolver actually writes to |
+| **BUG-03** | high | `cmod workspace add <dir>` registers an existing member if it has a `cmod.toml`, scaffolds if missing, rejects orphans — no more blanket "directory already exists" |
+| **BUG-04** | medium | `cmod run --release` now locates the binary in `build/release/` |
+| **BUG-05** | medium | Release builds now propagate profile / locked / offline / target settings into path-dep sub-builds |
+| **BUG-06** | low | `cmod cache push/pull` now accept `--remote <URL>` as a per-invocation override of `[cache].shared_url` |
+| **BUG-07** | low | Test harness no longer contaminates tempdirs with developer-built `build/` artefacts, so `cargo test --test example_projects` is stable across Clang versions |
+
+## New CLI surface
+
+```text
+$ cmod cache push --help
+Push local cache entries to remote cache
+
+Options:
+      --remote <URL>   Remote cache URL (overrides manifest [cache].shared_url)
+```
+
+## Under the hood
+
+- `cmod_core::types` gains two shared helpers — `is_acceptable_package_name` (validation) and `sanitize_package_name_for_path` (filesystem encoding). The resolver, vendor, verify, and policy crates all route through them, so on-disk dep directory naming has a single source of truth.
+- `BuildRunner` memoizes the compiler version via `OnceLock` to avoid re-running `clang --version` for every source file.
+- `ArtifactMetadata` now records `compiler_version` and `target` instead of empty strings.
+
+## Installation
+
+### Pre-built binaries
+
+```bash
+# Latest
+curl -sSf https://raw.githubusercontent.com/satishbabariya/cmod/main/install.sh | sh
+
+# Pin to this version
+curl -sSf https://raw.githubusercontent.com/satishbabariya/cmod/main/install.sh | sh -s -- --version v0.1.0-alpha.2
+```
+
+### From source
+
+```bash
+git clone https://github.com/satishbabariya/cmod.git
+cd cmod && git checkout v0.1.0-alpha.2
+cargo install --path crates/cmod-cli
+```
+
+### Download
+
+| Platform | Architecture | Archive |
+|----------|-------------|---------|
+| Linux | x86_64 (glibc) | `cmod-v0.1.0-alpha.2-x86_64-unknown-linux-gnu.tar.gz` |
+| Linux | aarch64 (glibc) | `cmod-v0.1.0-alpha.2-aarch64-unknown-linux-gnu.tar.gz` |
+| Linux | x86_64 (musl, static) | `cmod-v0.1.0-alpha.2-x86_64-unknown-linux-musl.tar.gz` |
+| macOS | x86_64 (Intel) | `cmod-v0.1.0-alpha.2-x86_64-apple-darwin.tar.gz` |
+| macOS | aarch64 (Apple Silicon) | `cmod-v0.1.0-alpha.2-aarch64-apple-darwin.tar.gz` |
+| Windows | x86_64 | `cmod-v0.1.0-alpha.2-x86_64-pc-windows-msvc.zip` |
+| Windows | aarch64 | `cmod-v0.1.0-alpha.2-aarch64-pc-windows-msvc.zip` |
+
+SHA-256 checksums are provided as `checksums-v0.1.0-alpha.2.sha256`.
+
+### Runtime requirements
+
+- **LLVM/Clang 17+** on `PATH`. On macOS, `brew install llvm@18` is recommended — Apple's bundled `/usr/bin/clang++` mis-handles the C++20 global module fragment.
+- **Git 2.25+** for fetching dependencies.
+
+## Feedback
+
+- Issues: https://github.com/satishbabariya/cmod/issues
+- Full changelog: https://github.com/satishbabariya/cmod/compare/v0.1.0-alpha.1...v0.1.0-alpha.2


### PR DESCRIPTION
## Summary

Audit-cleanup release. Three commits:

1. `chore: bump workspace version to 0.1.0-alpha.2`
2. `docs(changelog): section for v0.1.0-alpha.2`
3. `docs: release notes for v0.1.0-alpha.2`

Substantive content landed in PR #31 and #32:
- 7 audit bugs fixed (vendor / verify --signatures / workspace add / run --release / path-dep release profile / cache --remote / test harness)
- Cache key now includes compiler version — eliminates "older PCM format" errors after Clang upgrades
- rustls-webpki dependency bump (Dependabot #29)

## Upgrade notes

Two expected one-time behaviour changes (no action required):

- **One-time cache miss on first build** after upgrade (cache key changed).
- **First `cmod build --release` rebuilds path deps** — they were previously built in debug.

Full notes in `RELEASE.md`.

## Test plan

- [x] `cargo test --release --workspace` → 828 passed (verified on the squash of #31)
- [x] `cargo clippy --all-targets -- -D warnings` clean on rustc 1.95.0 (verified on #32)
- [x] `cargo fmt --all --check` clean
- [x] Live bug regression suite (`/tmp/cmod-test-outputs/regression.txt`)

After this PR merges: tag `v0.1.0-alpha.2` on main → release workflow builds 7 platform binaries → GitHub release drafted with `RELEASE.md` as body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)