### PR TITLE
fix(cli): make cache export output directory positional

### DIFF
--- a/crates/cmod-cli/src/main.rs
+++ b/crates/cmod-cli/src/main.rs
@@ -476,7 +476,6 @@ enum CacheAction {
         /// Cache key of the entry to export
         key: String,
         /// Output directory
-        #[arg(short, long)]
         output: String,
     },
     /// Import a BMI package into the local cache

--- a/crates/cmod-cli/tests/cli_integration.rs
+++ b/crates/cmod-cli/tests/cli_integration.rs
@@ -1218,6 +1218,7 @@ fn test_cache_export_import() {
     run_cmod(tmp.path(), &["init", "--name", "cache_exp"]);
 
     // cache export without a real cache entry should fail gracefully
+    // (all-positional: MODULE KEY OUTPUT — see #40)
     let output = run_cmod(
         tmp.path(),
         &[
@@ -1225,13 +1226,26 @@ fn test_cache_export_import() {
             "export",
             "nonexistent",
             "somekey",
-            "--output",
             tmp.path().join("export").to_str().unwrap(),
         ],
     );
     assert!(
         !output.status.success(),
         "expected cache export to fail for nonexistent module"
+    );
+
+    // the old flag form must now be rejected by clap
+    let output = run_cmod(
+        tmp.path(),
+        &["cache", "export", "nonexistent", "somekey", "--output", "x"],
+    );
+    assert!(
+        !output.status.success(),
+        "expected --output flag to be rejected after positional migration"
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("--output"),
+        "clap error should mention the unexpected --output flag"
     );
 
     // cache import without a package should fail gracefully

--- a/docs/guide/caching.md
+++ b/docs/guide/caching.md
@@ -83,7 +83,7 @@ cmod cache inspect <MODULE> <KEY>
 Export a cached module as a BMI package:
 
 ```bash
-cmod cache export <MODULE> <KEY> -o /path/to/output
+cmod cache export <MODULE> <KEY> /path/to/output
 ```
 
 ### Import a BMI package

--- a/docs/guide/cli-reference.md
+++ b/docs/guide/cli-reference.md
@@ -466,14 +466,14 @@ cmod cache inspect <MODULE> <KEY>
 Export a cached module as a BMI package.
 
 ```
-cmod cache export <MODULE> <KEY> -o <OUTPUT>
+cmod cache export <MODULE> <KEY> <OUTPUT>
 ```
 
-| Argument/Option | Description |
-|-----------------|-------------|
+| Argument | Description |
+|----------|-------------|
 | `<MODULE>` | Module name |
 | `<KEY>` | Cache key (hex) |
-| `-o <OUTPUT>` | Output directory |
+| `<OUTPUT>` | Output directory |
 
 ### `cmod cache import`
 


### PR DESCRIPTION
## Summary

Fixes #40 — `cache inspect` and `cache export` had inconsistent argument shapes:

- before: `cmod cache inspect <MODULE> <KEY>` vs `cmod cache export <MODULE> <KEY> --output <OUT>`
- after: both all-positional — `cmod cache export <MODULE> <KEY> <OUTPUT>` (the issue's preferred option)

Changes:
- `CacheAction::Export` — `output` loses `#[arg(short, long)]` and becomes the third positional
- `docs/guide/cli-reference.md` + `docs/guide/caching.md` updated to the new form
- integration test updated; new assertion pins that the old `--output` flag form is now rejected by clap

**Breaking CLI change** (acceptable pre-1.0, alpha line): `-o/--output` is no longer accepted. clap fails fast with an "unexpected argument '--output'" error, so scripts using the old form break loudly, not silently.

## Validation

Full suite: 831 passed, 0 failed. Clippy (1.97) and fmt clean. `cmod cache export --help` verified to show the new all-positional usage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Updated `cmod cache export` to accept the output path as a positional argument instead of the `--output` or `-o` option.

* **Documentation**
  * Updated caching guides and CLI reference documentation with the new command syntax.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->