### PR TITLE
feat(workspace): add --scaffold flag to cmod workspace add

### DIFF
--- a/crates/cmod-cli/src/commands/workspace.rs
+++ b/crates/cmod-cli/src/commands/workspace.rs
@@ -52,8 +52,8 @@ pub fn list(shell: &Shell) -> Result<(), CmodError> {
     Ok(())
 }
 
-/// Run `cmod workspace add <name>` — add a new member to the workspace.
-pub fn add(name: &str, shell: &Shell) -> Result<(), CmodError> {
+/// Run `cmod workspace add <name> [--scaffold]` — add a member to the workspace.
+pub fn add(name: &str, scaffold: bool, shell: &Shell) -> Result<(), CmodError> {
     let cwd = std::env::current_dir()?;
     let config = Config::load(&cwd)?;
 
@@ -67,7 +67,7 @@ pub fn add(name: &str, shell: &Shell) -> Result<(), CmodError> {
 
     shell.verbose("Adding", format!("member '{}' to workspace", name));
 
-    ws.add_member(name)?;
+    ws.add_member(name, scaffold)?;
 
     shell.status("Added", format!("member '{}' to workspace", name));
     shell.verbose("Created", format!("{}/src/lib.cppm", name));

--- a/crates/cmod-cli/src/main.rs
+++ b/crates/cmod-cli/src/main.rs
@@ -408,6 +408,9 @@ enum WorkspaceAction {
     Add {
         /// Name of the new member
         name: String,
+        /// Require scaffolding a new member (error if the directory exists)
+        #[arg(long)]
+        scaffold: bool,
     },
     /// Remove a member from the workspace
     Remove {
@@ -637,7 +640,9 @@ fn main() {
         Commands::Clean => commands::clean::run(&shell),
         Commands::Workspace { action } => match action {
             WorkspaceAction::List => commands::workspace::list(&shell),
-            WorkspaceAction::Add { name } => commands::workspace::add(&name, &shell),
+            WorkspaceAction::Add { name, scaffold } => {
+                commands::workspace::add(&name, scaffold, &shell)
+            }
             WorkspaceAction::Remove { name } => commands::workspace::remove(&name, &shell),
         },
         Commands::Sbom { output } => commands::sbom::run(output, &shell),

--- a/crates/cmod-cli/tests/cli_integration.rs
+++ b/crates/cmod-cli/tests/cli_integration.rs
@@ -838,6 +838,33 @@ fn test_workspace_list() {
 }
 
 #[test]
+fn test_workspace_add_scaffold() {
+    let tmp = TempDir::new().unwrap();
+    run_cmod(tmp.path(), &["init", "--workspace", "--name", "wsscaffold"]);
+
+    // --scaffold creates a fresh member
+    let output = run_cmod(tmp.path(), &["workspace", "add", "newmember", "--scaffold"]);
+    assert!(
+        output.status.success(),
+        "workspace add --scaffold should succeed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(tmp.path().join("newmember/cmod.toml").exists());
+
+    // --scaffold on an existing directory must fail with a helpful message
+    std::fs::create_dir_all(tmp.path().join("taken")).unwrap();
+    let output = run_cmod(tmp.path(), &["workspace", "add", "taken", "--scaffold"]);
+    assert!(
+        !output.status.success(),
+        "workspace add --scaffold over an existing dir should fail"
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("already exists"),
+        "error should mention the directory already exists"
+    );
+}
+
+#[test]
 fn test_resolve_with_target_flag() {
     let tmp = TempDir::new().unwrap();
     run_cmod(tmp.path(), &["init", "--name", "targettest"]);

--- a/crates/cmod-workspace/src/workspace.rs
+++ b/crates/cmod-workspace/src/workspace.rs
@@ -275,13 +275,16 @@ impl WorkspaceManager {
 
     /// Add a member to the workspace.
     ///
-    /// Behavior depends on what already exists at `<root>/<name>`:
+    /// With `must_scaffold`, the caller explicitly asserts a new member is
+    /// being created: the target directory must not exist at all.
+    ///
+    /// Without it, behavior is inferred from what exists at `<root>/<name>`:
     ///
     /// 1. **Dir exists with a `cmod.toml`** → register it (no scaffolding).
     /// 2. **Dir exists without a `cmod.toml`** → reject (ambiguous; caller
     ///    can delete the dir and retry, or add the manifest manually).
     /// 3. **Dir does not exist** → scaffold `src/lib.cppm` + `cmod.toml`.
-    pub fn add_member(&mut self, name: &str) -> Result<(), CmodError> {
+    pub fn add_member(&mut self, name: &str, must_scaffold: bool) -> Result<(), CmodError> {
         // Early-reject names that would be unsafe to use as path components.
         if name.is_empty() || name.contains("..") || name.starts_with('/') || name.starts_with('\\')
         {
@@ -300,6 +303,16 @@ impl WorkspaceManager {
 
         let member_dir = self.root.join(name);
         let manifest_path = member_dir.join("cmod.toml");
+
+        if must_scaffold && member_dir.exists() {
+            return Err(CmodError::InvalidManifest {
+                reason: format!(
+                    "cannot scaffold '{}': directory already exists; \
+                     omit --scaffold to register an existing member",
+                    name
+                ),
+            });
+        }
 
         let (member_manifest, scaffolded) = if member_dir.exists() {
             if !member_dir.is_dir() {
@@ -761,5 +774,61 @@ lib = { path = "./lib" }
         let tmp = TempDir::new().unwrap();
         let result = expand_member_patterns(tmp.path(), &["nonexistent".to_string()]).unwrap();
         assert!(result.is_empty());
+    }
+
+    // --- add_member scaffold intent (#41) ---
+
+    #[test]
+    fn test_add_member_scaffold_creates_new() {
+        let tmp = setup_workspace();
+        let mut ws = WorkspaceManager::load(tmp.path()).unwrap();
+
+        ws.add_member("newlib", true).unwrap();
+
+        assert!(tmp.path().join("newlib/cmod.toml").exists());
+        assert!(tmp.path().join("newlib/src/lib.cppm").exists());
+        assert!(ws.members.iter().any(|m| m.name == "newlib"));
+    }
+
+    #[test]
+    fn test_add_member_scaffold_rejects_existing_dir() {
+        let tmp = setup_workspace();
+        let mut ws = WorkspaceManager::load(tmp.path()).unwrap();
+
+        // Existing directory (even with a manifest) must be rejected when
+        // the caller explicitly asked to scaffold a new member.
+        let existing = tmp.path().join("preexisting");
+        std::fs::create_dir_all(existing.join("src")).unwrap();
+        cmod_core::manifest::default_manifest("preexisting")
+            .save(&existing.join("cmod.toml"))
+            .unwrap();
+
+        let err = ws.add_member("preexisting", true).unwrap_err();
+        assert!(
+            err.to_string().contains("already exists"),
+            "error should explain the directory already exists, got: {}",
+            err
+        );
+        // Nothing was registered
+        assert!(!ws.members.iter().any(|m| m.name == "preexisting"));
+    }
+
+    #[test]
+    fn test_add_member_without_scaffold_keeps_inference() {
+        let tmp = setup_workspace();
+        let mut ws = WorkspaceManager::load(tmp.path()).unwrap();
+
+        // Existing member dir with manifest → registered, not re-scaffolded
+        let existing = tmp.path().join("existing");
+        std::fs::create_dir_all(existing.join("src")).unwrap();
+        cmod_core::manifest::default_manifest("existing")
+            .save(&existing.join("cmod.toml"))
+            .unwrap();
+        ws.add_member("existing", false).unwrap();
+        assert!(ws.members.iter().any(|m| m.name == "existing"));
+
+        // Missing dir → scaffolded (unchanged legacy inference)
+        ws.add_member("fresh", false).unwrap();
+        assert!(tmp.path().join("fresh/cmod.toml").exists());
     }
 }

--- a/docs/guide/cli-reference.md
+++ b/docs/guide/cli-reference.md
@@ -557,11 +557,20 @@ cmod workspace list
 
 ### `cmod workspace add`
 
-Add a new member to the workspace.
+Add a member to the workspace.
 
 ```
-cmod workspace add <NAME>
+cmod workspace add <NAME> [--scaffold]
 ```
+
+Without flags, behavior is inferred: an existing directory with a
+`cmod.toml` is registered as-is; a missing directory is scaffolded with a
+starter `cmod.toml` and `src/lib.cppm`; an existing directory without a
+manifest is rejected.
+
+| Option | Description |
+|--------|-------------|
+| `--scaffold` | Require creating a new member; error if the directory already exists. Use in scripts to make intent explicit. |
 
 ### `cmod workspace remove`
 


### PR DESCRIPTION
## Summary

Closes #41 — `cmod workspace add` inferred its three behaviors (register existing member / scaffold new / reject orphan dir) purely from directory state, which scripts can't audit. This adds an explicit intent flag:

- `cmod workspace add <NAME> --scaffold` — **must** create a new member; errors with `cannot scaffold '<name>': directory already exists; omit --scaffold to register an existing member` if the directory exists in any form
- `cmod workspace add <NAME>` — unchanged inference (fully backward compatible)

Changes: `WorkspaceManager::add_member(name, must_scaffold)` in cmod-workspace, flag on `WorkspaceAction::Add`, threaded through `commands::workspace::add`, CLI reference docs updated.

## Design note

The flag is an assertion, not a mode switch: default behavior stays inferred so existing usage keeps working; scripts opt into strictness. Making register-only the default was considered and rejected as an unnecessary breaking change for this milestone.

## Tests (TDD)

Written first, watched fail (E0061 — API doesn't exist), then implemented:
- `test_add_member_scaffold_creates_new`
- `test_add_member_scaffold_rejects_existing_dir`
- `test_add_member_without_scaffold_keeps_inference`
- integration: `test_workspace_add_scaffold` (happy path + rejection with message through the real binary)

Full suite: 835 passed, 0 failed. Clippy (1.97) and fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)