### PR TITLE
fix(graph): explain per-member graphs when run at a workspace root

### DIFF
--- a/crates/cmod-cli/src/commands/graph.rs
+++ b/crates/cmod-cli/src/commands/graph.rs
@@ -106,7 +106,24 @@ pub fn run(
     let sources = runner::discover_sources_multi(&src_dirs, &exclude)?;
 
     if sources.is_empty() {
-        shell.status("Graph", "no source files found");
+        if config.manifest.is_workspace() {
+            let members = cmod_workspace::WorkspaceManager::load(&config.root)
+                .map(|ws| {
+                    ws.members
+                        .iter()
+                        .map(|m| m.name.clone())
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                })
+                .unwrap_or_default();
+            shell.warn(format!(
+                "workspace root has no sources; the graph is per-member — \
+                 cd into a member and run `cmod graph` there (members: {})",
+                if members.is_empty() { "none" } else { &members }
+            ));
+        } else {
+            shell.status("Graph", "no source files found");
+        }
         return Ok(());
     }
 

--- a/crates/cmod-cli/tests/cli_integration.rs
+++ b/crates/cmod-cli/tests/cli_integration.rs
@@ -838,6 +838,31 @@ fn test_workspace_list() {
 }
 
 #[test]
+fn test_graph_at_workspace_root_message() {
+    let tmp = TempDir::new().unwrap();
+    run_cmod(tmp.path(), &["init", "--workspace", "--name", "wsgraph"]);
+    run_cmod(tmp.path(), &["workspace", "add", "core", "--scaffold"]);
+
+    let output = run_cmod(tmp.path(), &["graph"]);
+    assert!(
+        output.status.success(),
+        "graph at workspace root should not fail: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("workspace root has no sources"),
+        "should explain the workspace-root situation, got: {}",
+        stderr
+    );
+    assert!(
+        stderr.contains("core"),
+        "should list member names to guide the user, got: {}",
+        stderr
+    );
+}
+
+#[test]
 fn test_workspace_add_scaffold() {
     let tmp = TempDir::new().unwrap();
     run_cmod(tmp.path(), &["init", "--workspace", "--name", "wsscaffold"]);


### PR DESCRIPTION
## Summary

Closes #42 — `cmod graph` at a workspace root printed the generic `Graph no source files found`, which reads like an error in a perfectly healthy workspace. It now warns:

```
warning: workspace root has no sources; the graph is per-member — cd into a member and run `cmod graph` there (members: core, app)
```

Single-module projects with no sources keep the previous message.

**Deviation from the issue's draft message:** the suggestion `run cmod graph -p <member>` references a `-p` flag that `cmod graph` does not have. Rather than advertise a nonexistent flag, the message lists the actual member names and directs the user to cd. (Adding `-p/--package` to `graph` would be a separate enhancement.)

## Tests (TDD)

`test_graph_at_workspace_root_message` written first and watched fail against the old output; asserts the explanation and that member names are listed, via the real binary. Full suite: 836 passed, 0 failed. Clippy (1.97) and fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)