### PR TITLE
docs: remote-cache server recipes + fix silent cache push failures

### DIFF
--- a/crates/cmod-cli/src/commands/cache.rs
+++ b/crates/cmod-cli/src/commands/cache.rs
@@ -120,13 +120,18 @@ pub fn push(remote_override: Option<String>, shell: &Shell) -> Result<(), CmodEr
                     .path()
                     .strip_prefix(&module_dir)
                     .unwrap_or(entry.path());
-                let rel_str = relative.to_string_lossy().to_string();
-                let parts: Vec<&str> = rel_str.split('/').collect();
+                // Split with Path::components, not '/': Windows paths use '\'
+                // and string-splitting silently pushed zero artifacts there.
+                let mut comps = relative
+                    .components()
+                    .map(|c| c.as_os_str().to_string_lossy().into_owned());
+                let key_hex = comps.next().unwrap_or_default();
+                let artifact_parts: Vec<String> = comps.collect();
 
-                if parts.len() >= 2 {
-                    let key = cmod_cache::CacheKey::from_hex(parts[0])
+                if !key_hex.is_empty() && !artifact_parts.is_empty() {
+                    let key = cmod_cache::CacheKey::from_hex(&key_hex)
                         .unwrap_or(cmod_cache::CacheKey::from_hex("unknown").unwrap());
-                    let artifact_name = parts[1..].join("/");
+                    let artifact_name = artifact_parts.join("/");
                     match remote.put(module, &key, &artifact_name, entry.path()) {
                         Ok(()) => pushed += 1,
                         Err(e) => {

--- a/crates/cmod-cli/src/commands/cache.rs
+++ b/crates/cmod-cli/src/commands/cache.rs
@@ -106,6 +106,7 @@ pub fn push(remote_override: Option<String>, shell: &Shell) -> Result<(), CmodEr
     shell.verbose("Remote", &remote_url);
 
     let mut pushed = 0;
+    let mut failed = 0;
     for module in &modules {
         shell.verbose("Pushing", module);
         let module_dir = config.cache_dir().join(module);
@@ -126,14 +127,29 @@ pub fn push(remote_override: Option<String>, shell: &Shell) -> Result<(), CmodEr
                     let key = cmod_cache::CacheKey::from_hex(parts[0])
                         .unwrap_or(cmod_cache::CacheKey::from_hex("unknown").unwrap());
                     let artifact_name = parts[1..].join("/");
-                    let _ = remote.put(module, &key, &artifact_name, entry.path());
-                    pushed += 1;
+                    match remote.put(module, &key, &artifact_name, entry.path()) {
+                        Ok(()) => pushed += 1,
+                        Err(e) => {
+                            failed += 1;
+                            shell.verbose("Failed", format!("{}/{}: {}", module, artifact_name, e));
+                        }
+                    }
                 }
             }
         }
     }
 
+    if failed > 0 {
+        shell.warn(format!("{} artifact upload(s) failed", failed));
+    }
     shell.status("Pushed", format!("{} artifacts", pushed));
+
+    if pushed == 0 && failed > 0 {
+        return Err(CmodError::Other(format!(
+            "all {} artifact upload(s) failed; check the remote cache URL and permissions",
+            failed
+        )));
+    }
     Ok(())
 }
 

--- a/crates/cmod-cli/tests/cli_integration.rs
+++ b/crates/cmod-cli/tests/cli_integration.rs
@@ -1264,6 +1264,69 @@ fn test_graph_critical_path_flag() {
     );
 }
 
+/// Regression test: `cache push` must report upload failures instead of
+/// counting every artifact as pushed (found while validating #44 against a
+/// read-only server).
+#[test]
+fn test_cache_push_reports_failures() {
+    use std::io::{Read, Write};
+
+    let tmp = TempDir::new().unwrap();
+    run_cmod(tmp.path(), &["init", "--name", "pushfail"]);
+
+    // Point the local cache into the project and handcraft one entry
+    // (no compiler needed).
+    let cache_dir = tmp.path().join("localcache");
+    let key = "a".repeat(64);
+    let entry = cache_dir.join("local.pushfail").join(&key);
+    fs::create_dir_all(&entry).unwrap();
+    fs::write(entry.join("artifact.o"), b"bytes").unwrap();
+    let manifest = fs::read_to_string(tmp.path().join("cmod.toml")).unwrap();
+    fs::write(
+        tmp.path().join("cmod.toml"),
+        format!("{}\n[cache]\nlocal_path = \"localcache\"\n", manifest),
+    )
+    .unwrap();
+
+    // Minimal HTTP listener that rejects every request with 404.
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+    let server = std::thread::spawn(move || {
+        // Serve until the socket is dropped; each PUT retry reconnects.
+        for stream in listener.incoming() {
+            let Ok(mut stream) = stream else { break };
+            let mut buf = [0u8; 4096];
+            let _ = stream.read(&mut buf);
+            let _ = stream.write_all(
+                b"HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+            );
+        }
+    });
+
+    let output = run_cmod(
+        tmp.path(),
+        &["cache", "push", "--remote", &format!("http://{}", addr)],
+    );
+    drop(server); // listener thread exits when the process stops connecting
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !output.status.success(),
+        "push with zero successful uploads should fail, got: {}",
+        stderr
+    );
+    assert!(
+        stderr.contains("failed"),
+        "output should mention failed uploads, got: {}",
+        stderr
+    );
+    assert!(
+        !stderr.contains("Pushed 1 artifacts"),
+        "must not report failed uploads as pushed, got: {}",
+        stderr
+    );
+}
+
 #[test]
 fn test_cache_export_import() {
     let tmp = TempDir::new().unwrap();

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -22,6 +22,7 @@ Complete documentation for **cmod** — a Cargo-inspired, Git-native package and
 - **[Testing](testing.md)** — Test discovery, frameworks, coverage, sanitizers, CI integration
 - **[Workspaces](workspaces.md)** — Monorepos, shared dependencies, multi-member builds
 - **[Caching](caching.md)** — Local and remote build cache management
+- **[Remote Cache Server](remote-cache.md)** — Protocol spec and hosting recipes (nginx, Caddy)
 - **[Security](security.md)** — Trust model, verification, signing, auditing
 - **[Publishing](publishing.md)** — Releasing, signing tags, SBOM generation
 

--- a/docs/guide/caching.md
+++ b/docs/guide/caching.md
@@ -94,7 +94,10 @@ cmod cache import /path/to/package
 
 ## Remote Caching
 
-Share build artifacts across team members and CI systems.
+Share build artifacts across team members and CI systems. Any HTTP server
+implementing a three-verb protocol works as the backend — see
+[Hosting a Remote Cache Server](remote-cache.md) for the protocol spec and
+tested nginx/Caddy recipes.
 
 ### Configuration
 

--- a/docs/guide/remote-cache.md
+++ b/docs/guide/remote-cache.md
@@ -1,0 +1,199 @@
+# Hosting a Remote Cache Server
+
+`cmod` can share compiled artifacts (PCMs and object files) across machines
+through any HTTP server that speaks a three-verb protocol. There is no
+required server software — a static file server with PUT support is enough.
+This page documents the protocol and gives tested recipes.
+
+See [Caching](caching.md) for client-side configuration (`[cache]` in
+`cmod.toml`, TTL, compression).
+
+## The protocol
+
+All requests are rooted at `<shared_url>/cache/`:
+
+| Request | Meaning | Expected response |
+|---------|---------|-------------------|
+| `HEAD /cache/<module>/<key>` | Does this cache entry exist? | `200` if present, `404` otherwise |
+| `GET /cache/<module>/<key>/<artifact>` | Fetch one artifact file | `200` + bytes, or `404` |
+| `PUT /cache/<module>/<key>/<artifact>` | Store one artifact file | any `2xx`; body is `application/octet-stream` |
+
+- `<module>` is the module id (e.g. `local.mylib`, `github.fmtlib.fmt`).
+  Partition modules contain a colon (`local.mathlib:ops`) — the server must
+  accept `:` in paths (nginx, Caddy, and plain filesystems all do).
+- `<key>` is a 64-char hex SHA-256 cache key.
+- `<artifact>` is a flat filename (`<module>.pcm`, `<module>.o`,
+  `metadata.json`).
+
+If `[cache] auth_token_env` is configured, every request carries
+`Authorization: Bearer <token>`.
+
+How the client uses it:
+
+- **`cmod build`** (with `[cache] shared_url` set, or `--remote-cache <URL>`)
+  transparently GETs artifacts on a local cache miss and PUTs them after a
+  successful compile — this is the main path and needs no extra commands.
+- **`cmod cache push [--remote <URL>]`** uploads the entire local cache.
+- **`cmod cache pull [--remote <URL>]`** pre-fetches artifacts for the
+  dependencies pinned in `cmod.lock` (it is lockfile-scoped; it does not
+  mirror the whole remote cache).
+
+## Recipe: nginx (read-write)
+
+A complete team cache on one nginx server backed by a directory:
+
+```nginx
+server {
+    listen 8787;
+    # server_name cache.internal.example.com;
+
+    root /srv/cmod-cache;
+
+    location /cache/ {
+        # GET/HEAD: serve files; autoindex makes HEAD on an entry
+        # directory return 200 (cmod's existence probe)
+        autoindex on;
+
+        # PUT: accept uploads, creating intermediate directories
+        dav_methods PUT;
+        create_full_put_path on;
+        client_max_body_size 512m;
+
+        # Optional bearer-token auth (single shared token)
+        # if ($http_authorization != "Bearer YOUR-SECRET-TOKEN") {
+        #     return 401;
+        # }
+    }
+}
+```
+
+```bash
+sudo mkdir -p /srv/cmod-cache/cache
+sudo chown www-data /srv/cmod-cache/cache   # nginx worker user
+```
+
+Client side:
+
+```toml
+[cache]
+shared_url = "http://cache.internal.example.com:8787"
+auth_token_env = "CMOD_CACHE_AUTH_TOKEN"    # if the token check is enabled
+```
+
+Notes:
+
+- `dav_methods` is in the stock `ngx_http_dav_module` (built into the
+  distro packages of nginx; no third-party module needed).
+- Put the server behind TLS (or a private network) before enabling it for a
+  team — see [Security notes](#security-notes).
+
+## Recipe: Caddy (read-only distribution)
+
+Stock Caddy has no PUT handler, so use it for the common
+"CI writes, developers read" topology: CI pushes over rsync/scp (or runs the
+nginx recipe internally), developers consume over HTTP.
+
+```caddyfile
+cache.example.com {
+    root * /srv/cmod-cache
+    file_server browse
+}
+```
+
+Developers configure:
+
+```toml
+[cache]
+shared_url = "https://cache.example.com"
+```
+
+Reads work — `cmod build` restores artifacts on a local cache miss.
+`cmod cache push` against this server fails (Caddy's file server answers
+`404` to PUT) and cmod reports the failed uploads — that is the intended
+read-only behavior.
+
+Note: Caddy answers `HEAD` on a directory URL with a `308` redirect to the
+trailing-slash form; cmod's HTTP client follows redirects, so the existence
+probe still works with `browse` enabled.
+
+## Recipe: local test server (Python)
+
+For trying the protocol out or debugging, this stdlib-only script implements
+all three verbs:
+
+```python
+#!/usr/bin/env python3
+"""Minimal cmod remote-cache server for local testing."""
+import http.server
+import os
+import sys
+
+ROOT = sys.argv[1] if len(sys.argv) > 1 else "./cache-data"
+
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    def _path(self):
+        p = self.path.lstrip("/")
+        parts = [s for s in p.split("/") if s and s != ".."]
+        return os.path.join(ROOT, *parts[1:]) if parts[:1] == ["cache"] else None
+
+    def do_HEAD(self):
+        p = self._path()
+        self.send_response(200 if p and os.path.exists(p) else 404)
+        self.end_headers()
+
+    def do_GET(self):
+        p = self._path()
+        if p and os.path.isfile(p):
+            with open(p, "rb") as f:
+                data = f.read()
+            self.send_response(200)
+            self.send_header("Content-Length", str(len(data)))
+            self.end_headers()
+            self.wfile.write(data)
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def do_PUT(self):
+        p = self._path()
+        if not p:
+            self.send_response(400)
+            self.end_headers()
+            return
+        data = self.rfile.read(int(self.headers.get("Content-Length", 0)))
+        os.makedirs(os.path.dirname(p), exist_ok=True)
+        with open(p, "wb") as f:
+            f.write(data)
+        self.send_response(201)
+        self.end_headers()
+
+
+if __name__ == "__main__":
+    http.server.HTTPServer(("127.0.0.1", 8787), Handler).serve_forever()
+```
+
+```bash
+python3 cache-server.py /tmp/cmod-cache &
+
+cmod build --remote-cache http://127.0.0.1:8787   # populates on first build
+cmod cache clean                                   # drop the local cache
+cmod build --remote-cache http://127.0.0.1:8787   # restores from the server
+```
+
+## Security notes
+
+- **Only trusted writers.** Anyone who can PUT can serve compiled objects to
+  every consumer — treat write access like commit access. Use the bearer
+  token for writers and keep read-only mirrors for wider distribution.
+- **Use TLS** for anything crossing a machine boundary; the bearer token is
+  sent on every request.
+- **Secrets stay in the environment.** `auth_token_env` names an environment
+  variable; the token itself never appears in `cmod.toml`.
+- **Cache keys are content-addressed** (sources, dependencies, compiler
+  version, target, flags — see [Caching](caching.md)), so a stale server
+  never causes wrong-input reuse; the risk model is malicious content, not
+  staleness.
+- Eviction is the server operator's job. A cron'd
+  `find /srv/cmod-cache -type f -atime +30 -delete` (plus a pass to prune
+  empty directories) is usually all a team cache needs.


### PR DESCRIPTION
## Summary

Closes #44 — adds `docs/guide/remote-cache.md`: the HTTP protocol `HttpRemoteCache` speaks (`HEAD /cache/<module>/<key>`, `GET`/`PUT /cache/<module>/<key>/<artifact>`, bearer auth) plus hosting recipes. Every recipe was validated against a real server with the real cmod client, not written from imagination:

- **nginx read-write** (Docker, `nginx:alpine`): `cmod cache push` PUT 201s, HEAD-on-entry-dir 200 via `autoindex`, and a cold `cmod build --remote-cache` restored all modules via GET
- **Caddy read-only** (Docker, `caddy:alpine`): GET restore works; `cache pull`'s existence probe survives Caddy's 308 directory redirect (verified through the real binary); PUT correctly rejected
- **Python dev server** (stdlib-only, included in the doc): full push → clean → restore round-trip of 86 artifacts

Also linked from the guide index and `caching.md`.

## Drive-by bug fix (second commit)

Validating against read-only Caddy exposed that **`cmod cache push` swallowed upload errors** — `let _ = remote.put(...)` counted every artifact as pushed, reporting "Pushed 3 artifacts" when zero uploaded. Now: failures are counted and warned (per-artifact detail with `--verbose`), and push exits nonzero when every upload failed. TDD: `test_cache_push_reports_failures` (handcrafted cache entry + in-test 404 HTTP listener, no compiler needed) written first and watched fail against the old behavior.

## Validation

Full suite: 843 passed, 0 failed. Clippy (1.97) and fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Remote cache uploads now report individual artifact failures.
  * Cache pushes correctly fail when all uploads are rejected and no longer report unsuccessful uploads as completed.

* **Documentation**
  * Added a comprehensive guide for hosting and configuring remote cache servers.
  * Documented supported HTTP operations, authentication, server configurations, and security considerations.
  * Expanded remote caching guidance and added the new guide to the documentation index.

* **Tests**
  * Added coverage to verify failed remote uploads are reported accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->