### PR TITLE
fix(cache): wire [cache] auth/timeout/retries end-to-end + atomic downloads

### DIFF
--- a/crates/cmod-cache/src/remote.rs
+++ b/crates/cmod-cache/src/remote.rs
@@ -230,7 +230,7 @@ impl RemoteCache for HttpRemoteCache {
                             return Ok(false);
                         }
 
-                        std::fs::write(dest, &data)?;
+                        write_artifact_atomic(dest, &data)?;
                         Ok(true)
                     } else if status == 404 {
                         Ok(false)
@@ -291,6 +291,21 @@ impl RemoteCache for HttpRemoteCache {
     }
 }
 
+/// Write downloaded artifact bytes atomically: write to a `.part` sibling,
+/// then rename over the destination. An interrupted download can never leave
+/// a truncated file that later reads as a valid cache artifact.
+fn write_artifact_atomic(dest: &Path, data: &[u8]) -> Result<(), CmodError> {
+    let mut tmp = dest.as_os_str().to_owned();
+    tmp.push(".part");
+    let tmp = std::path::PathBuf::from(tmp);
+
+    let result = std::fs::write(&tmp, data).and_then(|_| std::fs::rename(&tmp, dest));
+    if result.is_err() {
+        let _ = std::fs::remove_file(&tmp);
+    }
+    result.map_err(CmodError::from)
+}
+
 /// Configuration for remote cache (parsed from manifest `[cache]` section).
 #[derive(Debug, Clone)]
 pub struct RemoteCacheConfig {
@@ -326,6 +341,24 @@ impl Default for RemoteCacheConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_write_artifact_atomic_replaces_and_cleans_up() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let dest = tmp.path().join("artifact.o");
+        std::fs::write(&dest, b"old").unwrap();
+
+        write_artifact_atomic(&dest, b"new bytes").unwrap();
+
+        assert_eq!(std::fs::read(&dest).unwrap(), b"new bytes");
+        // No .part temp file may remain next to the destination
+        let leftovers = std::fs::read_dir(tmp.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_name().to_string_lossy().ends_with(".part"))
+            .count();
+        assert_eq!(leftovers, 0);
+    }
 
     #[test]
     fn test_remote_cache_mode_from_str() {

--- a/crates/cmod-cli/src/commands/build.rs
+++ b/crates/cmod-cli/src/commands/build.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use cmod_build::compiler::ClangBackend;
 use cmod_build::graph::{ModuleGraph, ModuleNode};
 use cmod_build::runner::{self, BuildRunner, BuildStats};
-use cmod_cache::{ArtifactCache, HttpRemoteCache, RemoteCacheMode};
+use cmod_cache::{ArtifactCache, RemoteCacheMode};
 use cmod_core::config::Config;
 use cmod_core::error::CmodError;
 use cmod_core::lockfile::Lockfile;
@@ -157,14 +157,17 @@ pub fn run(
     result
 }
 
-/// Create a remote cache instance from a URL, if provided.
+/// Create a remote cache instance from a URL, if provided, honoring the
+/// manifest's `[cache]` auth/timeout/retry settings.
 fn make_remote_cache(
+    config: &Config,
     url: &Option<String>,
     shell: &Shell,
 ) -> Option<Box<dyn cmod_cache::RemoteCache>> {
     let url = url.as_ref()?;
     shell.verbose("Remote cache", url);
-    Some(Box::new(HttpRemoteCache::new(
+    Some(Box::new(super::common::remote_cache_client(
+        config,
         url,
         RemoteCacheMode::ReadWrite,
     )))
@@ -254,7 +257,7 @@ fn build_module(
         .with_extra_obj_paths(dep_artifacts.objs)
         .with_shell(Arc::new(Shell::new(shell.verbosity())));
 
-    if let Some(remote) = make_remote_cache(remote_url, shell) {
+    if let Some(remote) = make_remote_cache(config, remote_url, shell) {
         runner = runner.with_remote_cache(remote);
     }
 
@@ -587,7 +590,7 @@ fn build_vendored_dependencies(
             .with_extra_obj_paths(extra_objs)
             .with_shell(Arc::new(Shell::new(shell.verbosity())));
 
-        if let Some(remote) = make_remote_cache(remote_url, shell) {
+        if let Some(remote) = make_remote_cache(config, remote_url, shell) {
             runner = runner.with_remote_cache(remote);
         }
 
@@ -833,7 +836,7 @@ fn build_workspace(
             .with_extra_pcm_paths(extra_pcms)
             .with_extra_obj_paths(extra_objs)
             .with_shell(Arc::new(Shell::new(shell.verbosity())));
-        if let Some(remote) = make_remote_cache(remote_url, shell) {
+        if let Some(remote) = make_remote_cache(config, remote_url, shell) {
             runner_instance = runner_instance.with_remote_cache(remote);
         }
         match runner_instance.build_with_stats(

--- a/crates/cmod-cli/src/commands/cache.rs
+++ b/crates/cmod-cli/src/commands/cache.rs
@@ -93,8 +93,11 @@ pub fn push(remote_override: Option<String>, shell: &Shell) -> Result<(), CmodEr
         )
     })?;
 
-    let remote =
-        cmod_cache::HttpRemoteCache::new(&remote_url, cmod_cache::RemoteCacheMode::ReadWrite);
+    let remote = super::common::remote_cache_client(
+        &config,
+        &remote_url,
+        cmod_cache::RemoteCacheMode::ReadWrite,
+    );
 
     let cache = ArtifactCache::new(config.cache_dir());
     let modules = cache.list_modules()?;
@@ -178,8 +181,11 @@ pub fn pull(remote_override: Option<String>, shell: &Shell) -> Result<(), CmodEr
         )
     })?;
 
-    let remote =
-        cmod_cache::HttpRemoteCache::new(&remote_url, cmod_cache::RemoteCacheMode::ReadOnly);
+    let remote = super::common::remote_cache_client(
+        &config,
+        &remote_url,
+        cmod_cache::RemoteCacheMode::ReadOnly,
+    );
 
     shell.verbose("Remote", &remote_url);
 

--- a/crates/cmod-cli/src/commands/common.rs
+++ b/crates/cmod-cli/src/commands/common.rs
@@ -29,6 +29,29 @@ impl DepArtifacts {
     }
 }
 
+/// Build an HTTP remote-cache client honoring the manifest's `[cache]`
+/// settings: `auth_token_env` (bearer token read from the environment),
+/// `timeout`, and `retries`.
+pub fn remote_cache_client(
+    config: &Config,
+    url: &str,
+    mode: cmod_cache::RemoteCacheMode,
+) -> cmod_cache::HttpRemoteCache {
+    let cache_cfg = config.manifest.cache.as_ref();
+    let token = cache_cfg
+        .and_then(|c| c.auth_token_env.as_deref())
+        .and_then(|name| std::env::var(name).ok());
+
+    let mut client = cmod_cache::HttpRemoteCache::new(url, mode).with_auth_token(token);
+    if let Some(secs) = cache_cfg.and_then(|c| c.timeout) {
+        client = client.with_timeout(std::time::Duration::from_secs(secs));
+    }
+    if let Some(retries) = cache_cfg.and_then(|c| c.retries) {
+        client = client.with_retries(retries);
+    }
+    client
+}
+
 /// Find a dependency on disk, checking `vendor/` first, then `build/deps/`.
 ///
 /// The vendor directory uses real path separators (e.g., `vendor/github.com/user/repo`),

--- a/crates/cmod-cli/tests/cli_integration.rs
+++ b/crates/cmod-cli/tests/cli_integration.rs
@@ -1264,6 +1264,74 @@ fn test_graph_critical_path_flag() {
     );
 }
 
+/// Regression test for #45: `[cache] auth_token_env` must be honored by
+/// `cache push` — the bearer token from the environment goes on the wire.
+#[test]
+fn test_cache_push_sends_bearer_token() {
+    use std::io::{Read, Write};
+    use std::sync::{Arc, Mutex};
+
+    let tmp = TempDir::new().unwrap();
+    run_cmod(tmp.path(), &["init", "--name", "authpush"]);
+
+    // Handcrafted cache entry + [cache] config with auth_token_env.
+    let cache_dir = tmp.path().join("localcache");
+    let key = "b".repeat(64);
+    let entry = cache_dir.join("local.authpush").join(&key);
+    fs::create_dir_all(&entry).unwrap();
+    fs::write(entry.join("artifact.o"), b"bytes").unwrap();
+    let manifest = fs::read_to_string(tmp.path().join("cmod.toml")).unwrap();
+    fs::write(
+        tmp.path().join("cmod.toml"),
+        format!(
+            "{}\n[cache]\nlocal_path = \"localcache\"\nauth_token_env = \"TEST_CACHE_TOKEN\"\n",
+            manifest
+        ),
+    )
+    .unwrap();
+
+    // Listener that records the Authorization header and accepts the upload.
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+    let seen_auth: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+    let seen_clone = Arc::clone(&seen_auth);
+    std::thread::spawn(move || {
+        for stream in listener.incoming() {
+            let Ok(mut stream) = stream else { break };
+            let mut buf = [0u8; 8192];
+            let n = stream.read(&mut buf).unwrap_or(0);
+            let req = String::from_utf8_lossy(&buf[..n]).to_string();
+            for line in req.lines() {
+                if line.to_ascii_lowercase().starts_with("authorization:") {
+                    seen_clone.lock().unwrap().push(line.trim().to_string());
+                }
+            }
+            let _ = stream.write_all(
+                b"HTTP/1.1 201 Created\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+            );
+        }
+    });
+
+    let output = Command::new(env!("CARGO_BIN_EXE_cmod"))
+        .args(["cache", "push", "--remote", &format!("http://{}", addr)])
+        .current_dir(tmp.path())
+        .env("TEST_CACHE_TOKEN", "sekrit-token-123")
+        .output()
+        .expect("failed to run cmod");
+
+    assert!(
+        output.status.success(),
+        "push should succeed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let auth = seen_auth.lock().unwrap();
+    assert!(
+        auth.iter().any(|h| h.contains("Bearer sekrit-token-123")),
+        "expected Authorization: Bearer header on the upload, saw: {:?}",
+        *auth
+    );
+}
+
 /// Regression test: `cache push` must report upload failures instead of
 /// counting every artifact as pushed (found while validating #44 against a
 /// read-only server).


### PR DESCRIPTION
## Summary

Closes #45 — the scope-check the issue asked for found that `[cache] auth_token_env`, `timeout`, and `retries` were **dead config**: documented in the guide, parsed into the manifest, and applied at none of the three `HttpRemoteCache` creation sites (`cmod build`, `cache push`, `cache pull`). All three now go through a shared `common::remote_cache_client()` that reads the bearer token from the configured env var and applies timeout/retries.

Also hardens downloads: `get()` writes to a `.part` sibling and renames into place, so an interrupted transfer can never leave a truncated file that later reads as a valid cache artifact.

**Scope split:** resumable/partial uploads need a protocol design decision first (plain nginx/Caddy can't resume PUTs) — filed as #62 per the issue's own scope note.

## Tests (TDD)

- `test_cache_push_sends_bearer_token` — in-test HTTP listener capturing headers; watched fail (`Authorization` never sent), passes after wiring
- `test_write_artifact_atomic_replaces_and_cleans_up` — unit test for the atomic write helper (watched fail E0425)

Full suite: 845 passed, 0 failed. Clippy (1.97) and fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Remote cache operations now support configured authentication, timeouts, and retries.
  * Cache uploads send bearer tokens configured through the manifest and environment.

* **Bug Fixes**
  * Downloads are written atomically, preventing incomplete artifacts from replacing valid cache entries.
  * Temporary download files are cleaned up after successful transfers.

* **Tests**
  * Added coverage for authentication headers and atomic cache replacement behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->