### PR TITLE
docs: document compiler-detection order

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,8 +4,8 @@ Thank you for your interest in contributing to cmod! This guide will help you ge
 
 ## Prerequisites
 
-- **Rust 1.74+** — install via [rustup](https://rustup.rs/)
-- **LLVM/Clang 17+** — required for C++ module compilation
+- **Rust 1.80+** — install via [rustup](https://rustup.rs/)
+- **LLVM/Clang 17+** — required for C++ module compilation; cmod resolves the compiler via `CXX` → `clang++` on `PATH` (see [compiler detection](docs/guide/toolchains.md#compiler-detection))
 - **Git** — for dependency resolution and version control
 
 ## Getting Started

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@
 
 ### Prerequisites
 
-- **Rust 1.74+** — [rustup.rs](https://rustup.rs/)
-- **LLVM/Clang 17+** — for C++ module compilation
+- **Rust 1.80+** — [rustup.rs](https://rustup.rs/)
+- **LLVM/Clang 17+** — for C++ module compilation (see [compiler detection](docs/guide/toolchains.md#compiler-detection) for how cmod finds it, and the macOS note if Apple clang is your default)
 
 ### Install (pre-built binary)
 

--- a/docs/guide/toolchains.md
+++ b/docs/guide/toolchains.md
@@ -46,6 +46,45 @@ stdlib = "libc++"      # LLVM's libc++ (common on macOS, recommended with Clang)
 
 The standard library choice affects ABI compatibility and cache keys.
 
+## Compiler Detection
+
+cmod resolves which binaries to invoke in a fixed order — there is no
+config-file search or automatic Homebrew probing:
+
+| Binary | 1. Environment variable | 2. `PATH` lookup | 3. Fallback |
+|--------|------------------------|------------------|-------------|
+| C++ compiler | `CXX` | first `clang++` on `PATH` | literal `clang++` (OS lookup at spawn) |
+| Dependency scanner | `SCAN_DEPS` | first `clang-scan-deps` on `PATH` | literal `clang-scan-deps` |
+
+The environment variables take absolute precedence and accept full paths:
+
+```bash
+CXX=/opt/homebrew/opt/llvm@18/bin/clang++ \
+SCAN_DEPS=/opt/homebrew/opt/llvm@18/bin/clang-scan-deps \
+cmod build
+```
+
+`cmod toolchain show` prints the resolved configuration (compiler, standard,
+target); `cmod toolchain check` verifies the detected compiler executes.
+
+### macOS note
+
+Apple's Xcode `clang++` (what a bare `clang++` resolves to) does not support
+C++20 modules the way cmod drives them — builds fail with errors like
+`unknown type name 'module'`. Install LLVM via Homebrew and make it win one
+of the two detection steps:
+
+```bash
+brew install llvm@18
+
+# Option A: put it first on PATH (affects everything in the shell)
+export PATH="/opt/homebrew/opt/llvm@18/bin:$PATH"
+
+# Option B: pin just cmod's binaries (per-project .envrc works well)
+export CXX=/opt/homebrew/opt/llvm@18/bin/clang++
+export SCAN_DEPS=/opt/homebrew/opt/llvm@18/bin/clang-scan-deps
+```
+
 ## Toolchain Commands
 
 ### Show active toolchain


### PR DESCRIPTION
## Summary

Closes #49 — adds a **Compiler Detection** section to `docs/guide/toolchains.md` documenting the verified resolution order:

| Binary | 1st | 2nd | 3rd |
|---|---|---|---|
| compiler | `CXX` env var | `clang++` on `PATH` | literal `clang++` |
| scanner | `SCAN_DEPS` env var | `clang-scan-deps` on `PATH` | literal name |

plus the macOS section explaining that Apple clang fails on C++20 modules (`unknown type name 'module'`) and how to make Homebrew LLVM win detection.

**Correction to the issue:** it described the order as `CXX → clang++ on PATH → Homebrew llvm@18`, but there is **no automatic Homebrew fallback** in `ClangBackend::new` — the docs describe what the code actually does and present Homebrew LLVM as the manual macOS remedy. Every claim was verified against `crates/cmod-build/src/compiler.rs` and by running `cmod toolchain show`.

Also: README and CONTRIBUTING prerequisites now point at the new section, and their stale "Rust 1.74+" was corrected to 1.80 (raised in #37).

Docs-only change — no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)