### PR TITLE
feat(build): abstract compiler construction behind the CompilerBackend trait

### DIFF
--- a/crates/cmod-build/src/compiler.rs
+++ b/crates/cmod-build/src/compiler.rs
@@ -8,7 +8,7 @@ use cmod_core::types::{Artifact, OptimizationLevel, Profile};
 ///
 /// The reference implementation targets Clang/LLVM. GCC and MSVC backends
 /// are planned for future tiers.
-pub trait CompilerBackend {
+pub trait CompilerBackend: Send + Sync {
     /// Scan a source file for module dependencies.
     ///
     /// Returns a list of module names that the source imports.
@@ -34,6 +34,28 @@ pub trait CompilerBackend {
 
     /// Link object files into a final artifact.
     fn link(&self, objects: &[&Path], output: &Path, artifact: &Artifact) -> Result<(), CmodError>;
+
+    /// Which compiler family this backend drives.
+    fn kind(&self) -> cmod_core::types::Compiler;
+
+    /// Path to the compiler executable (for compile_commands.json).
+    fn compiler_path(&self) -> &Path;
+
+    /// Detected compiler version string (e.g. `"18.1.8"`). Seeds cache keys.
+    fn version(&self) -> String;
+
+    /// The configured C++ standard (e.g. `"20"`).
+    fn cxx_standard(&self) -> &str;
+
+    /// The configured target triple, if any.
+    fn target(&self) -> Option<&str>;
+
+    /// Flags common to all compilations (compile_commands.json, diagnostics).
+    fn common_flags(&self) -> Vec<String>;
+
+    /// Deterministic description of every configuration input that affects
+    /// codegen. Hashed into incremental-build state and cache keys.
+    fn fingerprint(&self) -> String;
 }
 
 /// LTO mode for link-time optimization.
@@ -44,6 +66,52 @@ pub enum LtoMode {
     Thin,
     /// Full LTO — slower but maximum optimization.
     Full,
+}
+
+/// Compiler-agnostic configuration for constructing a backend.
+///
+/// Carries every knob that affects codegen so backends can be built through
+/// [`make_backend`] without poking concrete fields afterwards.
+#[derive(Debug, Clone, Default)]
+pub struct BackendConfig {
+    /// C++ standard (e.g., "20", "23").
+    pub cxx_standard: String,
+    /// Build profile.
+    pub profile: Profile,
+    /// Standard library (e.g., "libc++", "libstdc++").
+    pub stdlib: Option<String>,
+    /// Sysroot path for cross-compilation.
+    pub sysroot: Option<PathBuf>,
+    /// Target triple.
+    pub target: Option<String>,
+    /// Additional flags (includes, defines, user extra_flags).
+    pub extra_flags: Vec<String>,
+    /// Enable LTO.
+    pub lto: bool,
+    /// LTO mode.
+    pub lto_mode: LtoMode,
+    /// Explicit optimization level (overrides profile-based defaults).
+    pub optimization: Option<OptimizationLevel>,
+}
+
+/// Construct a compiler backend for the requested compiler family.
+///
+/// Clang is fully supported. GCC and MSVC return a clear error until their
+/// backends land (#47 groundwork / #48 skeleton).
+pub fn make_backend(
+    kind: cmod_core::types::Compiler,
+    config: &BackendConfig,
+) -> Result<Box<dyn CompilerBackend>, CmodError> {
+    match kind {
+        cmod_core::types::Compiler::Clang => Ok(Box::new(ClangBackend::from_config(config))),
+        other => Err(CmodError::BuildFailed {
+            reason: format!(
+                "the {} backend is not yet implemented; set [toolchain] compiler = \"clang\" \
+                 (or remove the line) — see issue #47",
+                other
+            ),
+        }),
+    }
 }
 
 /// Clang/LLVM compiler backend.
@@ -92,6 +160,19 @@ impl ClangBackend {
             lto_mode: LtoMode::default(),
             optimization: None,
         }
+    }
+
+    /// Create a Clang backend from a full [`BackendConfig`].
+    pub fn from_config(config: &BackendConfig) -> Self {
+        let mut backend = ClangBackend::new(&config.cxx_standard, config.profile);
+        backend.stdlib = config.stdlib.clone();
+        backend.sysroot = config.sysroot.clone();
+        backend.target = config.target.clone();
+        backend.extra_flags = config.extra_flags.clone();
+        backend.lto = config.lto;
+        backend.lto_mode = config.lto_mode;
+        backend.optimization = config.optimization;
+        backend
     }
 
     /// Query the compiler for its version string (e.g. `"18.1.8"`).
@@ -330,6 +411,48 @@ impl CompilerBackend for ClangBackend {
         Ok(())
     }
 
+    fn kind(&self) -> cmod_core::types::Compiler {
+        cmod_core::types::Compiler::Clang
+    }
+
+    fn compiler_path(&self) -> &Path {
+        &self.clang_path
+    }
+
+    fn version(&self) -> String {
+        self.detect_version()
+    }
+
+    fn cxx_standard(&self) -> &str {
+        &self.cxx_standard
+    }
+
+    fn target(&self) -> Option<&str> {
+        self.target.as_deref()
+    }
+
+    fn common_flags(&self) -> Vec<String> {
+        ClangBackend::common_flags(self)
+    }
+
+    fn fingerprint(&self) -> String {
+        format!(
+            "clang|std={}|stdlib={}|target={}|sysroot={}|profile={:?}|lto={}:{:?}|opt={:?}|flags={}",
+            self.cxx_standard,
+            self.stdlib.as_deref().unwrap_or(""),
+            self.target.as_deref().unwrap_or(""),
+            self.sysroot
+                .as_ref()
+                .map(|p| p.display().to_string())
+                .unwrap_or_default(),
+            self.profile,
+            self.lto,
+            self.lto_mode,
+            self.optimization,
+            self.extra_flags.join(" "),
+        )
+    }
+
     fn link(&self, objects: &[&Path], output: &Path, artifact: &Artifact) -> Result<(), CmodError> {
         let mut cmd = Command::new(&self.clang_path);
         cmd.args(self.common_flags());
@@ -446,6 +569,83 @@ fn which(name: &str) -> Option<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // --- backend factory and trait-object groundwork (#47) ---
+
+    #[test]
+    fn test_make_backend_clang() {
+        let cfg = BackendConfig {
+            cxx_standard: "20".to_string(),
+            ..Default::default()
+        };
+        let backend = make_backend(cmod_core::types::Compiler::Clang, &cfg).unwrap();
+        assert_eq!(backend.kind(), cmod_core::types::Compiler::Clang);
+        assert_eq!(backend.cxx_standard(), "20");
+    }
+
+    #[test]
+    fn test_make_backend_gcc_not_implemented() {
+        let cfg = BackendConfig::default();
+        let Err(err) = make_backend(cmod_core::types::Compiler::Gcc, &cfg) else {
+            panic!("gcc backend must not construct yet");
+        };
+        assert!(
+            err.to_string().contains("not yet implemented"),
+            "gcc should error clearly, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_make_backend_msvc_not_implemented() {
+        let cfg = BackendConfig::default();
+        let Err(err) = make_backend(cmod_core::types::Compiler::Msvc, &cfg) else {
+            panic!("msvc backend must not construct yet");
+        };
+        assert!(err.to_string().contains("not yet implemented"));
+    }
+
+    #[test]
+    fn test_backend_config_carries_all_knobs() {
+        let cfg = BackendConfig {
+            cxx_standard: "23".to_string(),
+            profile: Profile::Release,
+            stdlib: Some("libc++".to_string()),
+            sysroot: Some(PathBuf::from("/sdk")),
+            target: Some("x86_64-unknown-linux-gnu".to_string()),
+            extra_flags: vec!["-DFOO=1".to_string()],
+            lto: true,
+            lto_mode: LtoMode::Thin,
+            optimization: None,
+        };
+        let backend = make_backend(cmod_core::types::Compiler::Clang, &cfg).unwrap();
+        let flags = backend.common_flags();
+        assert!(flags.contains(&"-std=c++23".to_string()));
+        assert!(flags.contains(&"-stdlib=libc++".to_string()));
+        assert!(flags.contains(&"-DFOO=1".to_string()));
+        assert!(flags.iter().any(|f| f.contains("x86_64-unknown-linux")));
+    }
+
+    #[test]
+    fn test_fingerprint_changes_with_config() {
+        let base = BackendConfig {
+            cxx_standard: "20".to_string(),
+            ..Default::default()
+        };
+        let a = make_backend(cmod_core::types::Compiler::Clang, &base).unwrap();
+        let b = make_backend(
+            cmod_core::types::Compiler::Clang,
+            &BackendConfig {
+                cxx_standard: "23".to_string(),
+                ..base.clone()
+            },
+        )
+        .unwrap();
+        assert_ne!(a.fingerprint(), b.fingerprint());
+        // Deterministic for identical config
+        let a2 = make_backend(cmod_core::types::Compiler::Clang, &base).unwrap();
+        assert_eq!(a.fingerprint(), a2.fingerprint());
+    }
 
     #[test]
     fn test_parse_p1689_imports() {

--- a/crates/cmod-build/src/plan.rs
+++ b/crates/cmod-build/src/plan.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use cmod_core::error::CmodError;
 use cmod_core::types::{BuildType, NodeKind, Profile};
 
-use crate::compiler::ClangBackend;
+use crate::compiler::CompilerBackend;
 use crate::graph::ModuleGraph;
 
 /// A single step in the build plan.
@@ -240,7 +240,7 @@ impl BuildPlan {
     /// or object node) and includes the full clang++ invocation arguments.
     pub fn compile_commands(
         &self,
-        backend: &ClangBackend,
+        backend: &dyn CompilerBackend,
         project_root: &Path,
     ) -> Vec<CompileCommand> {
         let pcm_paths = self.pcm_paths();
@@ -256,7 +256,7 @@ impl BuildPlan {
                 continue;
             }
 
-            let mut arguments = vec!["clang++".to_string()];
+            let mut arguments = vec![backend.compiler_path().display().to_string()];
             arguments.extend(backend.common_flags());
 
             // Add dependency PCM references
@@ -764,7 +764,7 @@ mod tests {
         )
         .unwrap();
 
-        let backend = ClangBackend::new("20", Profile::Debug);
+        let backend = crate::compiler::ClangBackend::new("20", Profile::Debug);
         let commands = plan.compile_commands(&backend, Path::new("/project"));
 
         // Should have 2 entries (interface + implementation), not the link node
@@ -799,7 +799,7 @@ mod tests {
         )
         .unwrap();
 
-        let backend = ClangBackend::new("20", Profile::Debug);
+        let backend = crate::compiler::ClangBackend::new("20", Profile::Debug);
         let commands = plan.compile_commands(&backend, Path::new("/project"));
 
         let json = serde_json::to_string_pretty(&commands).unwrap();
@@ -834,7 +834,7 @@ mod tests {
         // plan has 2 nodes: object + link
         assert_eq!(plan.nodes.len(), 2);
 
-        let backend = ClangBackend::new("20", Profile::Debug);
+        let backend = crate::compiler::ClangBackend::new("20", Profile::Debug);
         let commands = plan.compile_commands(&backend, Path::new("/project"));
 
         // Should only have 1 entry (the object node, not the link)
@@ -907,7 +907,7 @@ mod tests {
         )
         .unwrap();
 
-        let backend = ClangBackend::new("20", Profile::Debug);
+        let backend = crate::compiler::ClangBackend::new("20", Profile::Debug);
         let commands = plan.compile_commands(&backend, Path::new("/project"));
 
         assert_eq!(commands.len(), 2);

--- a/crates/cmod-build/src/runner.rs
+++ b/crates/cmod-build/src/runner.rs
@@ -13,7 +13,7 @@ use cmod_core::error::CmodError;
 use cmod_core::shell::Shell;
 use cmod_core::types::{Artifact, BuildType, NodeKind, Profile};
 
-use crate::compiler::{ClangBackend, CompilerBackend};
+use crate::compiler::CompilerBackend;
 use crate::graph::ModuleGraph;
 use crate::incremental::BuildState;
 use crate::plan::{BuildNode, BuildPlan};
@@ -39,7 +39,7 @@ pub struct BuildStats {
 
 /// Build runner that executes a build plan.
 pub struct BuildRunner {
-    backend: ClangBackend,
+    backend: Box<dyn CompilerBackend>,
     cache: Option<ArtifactCache>,
     remote_cache: Option<Box<dyn cmod_cache::RemoteCache>>,
     /// When true, skip cache lookups and always recompile.
@@ -84,7 +84,7 @@ impl NodeOutcome {
 }
 
 impl BuildRunner {
-    pub fn new(backend: ClangBackend, cache: Option<ArtifactCache>) -> Self {
+    pub fn new(backend: Box<dyn CompilerBackend>, cache: Option<ArtifactCache>) -> Self {
         BuildRunner {
             backend,
             cache,
@@ -105,7 +105,7 @@ impl BuildRunner {
     /// on the first call.
     fn compiler_version(&self) -> &str {
         self.compiler_version_cache
-            .get_or_init(|| self.backend.detect_version())
+            .get_or_init(|| self.backend.version())
     }
 
     /// Set the maximum parallel jobs.
@@ -187,30 +187,16 @@ impl BuildRunner {
                 continue;
             }
 
-            // Derive compiler info from the backend fields.
-            // ClangBackend doesn't expose dedicated accessor methods, so we
-            // use the executable name and field values directly.
-            let compiler_name = self
-                .backend
-                .clang_path
-                .file_stem()
-                .and_then(|s| s.to_str())
-                .unwrap_or("clang++");
-            // Normalize "clang++" to "clang" for BMI index matching.
-            let compiler = if compiler_name.contains("clang") {
-                "clang"
-            } else {
-                compiler_name
-            };
+            let compiler = self.backend.kind().to_string();
             let compiler_version = self.compiler_version();
-            let target = self.backend.target.as_deref().unwrap_or("");
+            let target = self.backend.target().unwrap_or("");
 
             if let Some(variant) = cmod_cache::distribution::find_compatible_variant(
                 &index,
-                compiler,
+                &compiler,
                 compiler_version,
                 target,
-                &self.backend.cxx_standard,
+                self.backend.cxx_standard(),
             ) {
                 let variant_dir = bmi_dir.join(&variant.directory);
                 if variant_dir.exists() {
@@ -264,28 +250,11 @@ impl BuildRunner {
         }
     }
 
-    /// Compute a hash representing the current compiler flags.
+    /// Compute a hash representing the current compiler configuration.
     fn flags_hash(&self) -> String {
         use sha2::{Digest, Sha256};
         let mut hasher = Sha256::new();
-        hasher.update(self.backend.cxx_standard.as_bytes());
-        if let Some(ref stdlib) = self.backend.stdlib {
-            hasher.update(stdlib.as_bytes());
-        }
-        if let Some(ref target) = self.backend.target {
-            hasher.update(target.as_bytes());
-        }
-        for flag in &self.backend.extra_flags {
-            hasher.update(flag.as_bytes());
-        }
-        if let Some(ref sysroot) = self.backend.sysroot {
-            hasher.update(sysroot.to_string_lossy().as_bytes());
-        }
-        let profile_str = match self.backend.profile {
-            Profile::Debug => "debug",
-            Profile::Release => "release",
-        };
-        hasher.update(profile_str.as_bytes());
+        hasher.update(self.backend.fingerprint().as_bytes());
         format!("{:x}", hasher.finalize())
     }
 
@@ -366,19 +335,20 @@ impl BuildRunner {
             }
         }
 
-        let cxx_standard = self.backend.cxx_standard.clone();
-        let stdlib = self.backend.stdlib.clone().unwrap_or_default();
         let compiler_version = self.compiler_version().to_string();
 
+        // The backend fingerprint covers stdlib, sysroot, LTO, optimization,
+        // and extra flags — everything configuration-derived that affects
+        // codegen — so those no longer need individual fields here.
         let inputs = CacheKeyInputs {
             source_hash,
             dependency_hashes: dep_hashes,
-            compiler: "clang".to_string(),
+            compiler: self.backend.kind().to_string(),
             compiler_version,
-            cxx_standard,
-            stdlib,
+            cxx_standard: self.backend.cxx_standard().to_string(),
+            stdlib: String::new(),
             target: plan.target.clone(),
-            flags: self.backend.extra_flags.clone(),
+            flags: vec![self.backend.fingerprint()],
         };
 
         Some((module_id.clone(), CacheKey::compute(&inputs)))
@@ -498,9 +468,13 @@ impl BuildRunner {
                 module_name: module_id.to_string(),
                 cache_key: key.to_string(),
                 source_hash,
-                compiler: "clang".to_string(),
+                compiler: self.backend.kind().to_string(),
                 compiler_version: self.compiler_version().to_string(),
-                target: self.backend.target.clone().unwrap_or_default(),
+                target: self
+                    .backend
+                    .target()
+                    .map(str::to_string)
+                    .unwrap_or_default(),
                 created_at: String::new(),
                 artifacts: artifact_entries,
             };
@@ -1752,7 +1726,7 @@ mod tests {
     #[test]
     fn test_effective_jobs_auto() {
         let backend = crate::compiler::ClangBackend::new("20", cmod_core::types::Profile::Debug);
-        let runner = BuildRunner::new(backend, None);
+        let runner = BuildRunner::new(Box::new(backend), None);
         // auto-detect should be at least 1
         assert!(runner.effective_jobs() >= 1);
     }
@@ -1760,7 +1734,7 @@ mod tests {
     #[test]
     fn test_effective_jobs_explicit() {
         let backend = crate::compiler::ClangBackend::new("20", cmod_core::types::Profile::Debug);
-        let runner = BuildRunner::new(backend, None).with_jobs(4);
+        let runner = BuildRunner::new(Box::new(backend), None).with_jobs(4);
         assert_eq!(runner.effective_jobs(), 4);
     }
 

--- a/crates/cmod-cli/src/commands/build.rs
+++ b/crates/cmod-cli/src/commands/build.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use cmod_build::compiler::ClangBackend;
+use cmod_build::compiler::BackendConfig;
 use cmod_build::graph::{ModuleGraph, ModuleNode};
 use cmod_build::runner::{self, BuildRunner, BuildStats};
 use cmod_cache::{ArtifactCache, RemoteCacheMode};
@@ -8,7 +8,7 @@ use cmod_core::config::Config;
 use cmod_core::error::CmodError;
 use cmod_core::lockfile::Lockfile;
 use cmod_core::shell::{Shell, Verbosity};
-use cmod_core::types::Profile;
+use cmod_core::types::{Compiler, Profile};
 use cmod_resolver::Resolver;
 use cmod_workspace::WorkspaceManager;
 
@@ -230,12 +230,15 @@ fn build_module(
     }
 
     // Set up the compiler backend (with feature flags as -D defines)
-    let (mut backend, target) = setup_compiler(config, activated_features);
+    let (mut backend_cfg, compiler_kind, target) = setup_compiler(config, activated_features);
 
     // Add dependency include directories as -I flags
     for inc_dir in &dep_artifacts.include_dirs {
-        backend.extra_flags.push(format!("-I{}", inc_dir.display()));
+        backend_cfg
+            .extra_flags
+            .push(format!("-I{}", inc_dir.display()));
     }
+    let backend = cmod_build::compiler::make_backend(compiler_kind, &backend_cfg)?;
 
     // Set up cache
     let cache = ArtifactCache::new(config.cache_dir());
@@ -541,19 +544,24 @@ fn build_vendored_dependencies(
         graph.validate()?;
 
         // Set up compiler from the dependency's own toolchain config
-        let (mut backend, target) = setup_compiler(&dep_config, &[]);
+        let (mut backend_cfg, compiler_kind, target) = setup_compiler(&dep_config, &[]);
 
         // Add auto-detected include dirs to the dep's own compiler flags
         for inc_dir in &inc_dirs {
-            backend.extra_flags.push(format!("-I{}", inc_dir.display()));
+            backend_cfg
+                .extra_flags
+                .push(format!("-I{}", inc_dir.display()));
         }
 
         // Also add include dirs from already-processed deps (transitive)
         for inc_dir in &artifacts.include_dirs {
             if !inc_dirs.contains(inc_dir) {
-                backend.extra_flags.push(format!("-I{}", inc_dir.display()));
+                backend_cfg
+                    .extra_flags
+                    .push(format!("-I{}", inc_dir.display()));
             }
         }
+        let backend = cmod_build::compiler::make_backend(compiler_kind, &backend_cfg)?;
 
         // Set up cache
         let cache = ArtifactCache::new(dep_config.cache_dir());
@@ -752,29 +760,31 @@ fn build_workspace(
 
         let graph = build_module_graph(&sources, &member.name)?;
         graph.validate()?;
-        let (mut backend, target) = setup_compiler(config, &[]);
+        let (mut backend_cfg, compiler_kind, target) = setup_compiler(config, &[]);
 
         // Add member-specific include dirs and extra flags from [build] section
         if let Some(ref build) = member.manifest.build {
             for dir in &build.include_dirs {
                 let abs = member.path.join(dir);
-                backend.extra_flags.push(format!("-I{}", abs.display()));
+                backend_cfg.extra_flags.push(format!("-I{}", abs.display()));
             }
-            backend.extra_flags.extend(build.extra_flags.clone());
+            backend_cfg.extra_flags.extend(build.extra_flags.clone());
         }
 
         // Auto-detect include/ directory for this member
         let member_include = member.path.join("include");
         if member_include.is_dir() {
             let flag = format!("-I{}", member_include.display());
-            if !backend.extra_flags.contains(&flag) {
-                backend.extra_flags.push(flag);
+            if !backend_cfg.extra_flags.contains(&flag) {
+                backend_cfg.extra_flags.push(flag);
             }
         }
 
         // Add git dependency include dirs to the compiler
         for inc_dir in &git_dep_artifacts.include_dirs {
-            backend.extra_flags.push(format!("-I{}", inc_dir.display()));
+            backend_cfg
+                .extra_flags
+                .push(format!("-I{}", inc_dir.display()));
         }
 
         let cache = ArtifactCache::new(config.cache_dir());
@@ -805,8 +815,8 @@ fn build_workspace(
             if let Some(dep_incs) = member_include_dirs.get(dep_name) {
                 for inc_dir in dep_incs {
                     let flag = format!("-I{}", inc_dir.display());
-                    if !backend.extra_flags.contains(&flag) {
-                        backend.extra_flags.push(flag);
+                    if !backend_cfg.extra_flags.contains(&flag) {
+                        backend_cfg.extra_flags.push(flag);
                     }
                 }
             }
@@ -829,6 +839,7 @@ fn build_workspace(
             );
         }
 
+        let backend = cmod_build::compiler::make_backend(compiler_kind, &backend_cfg)?;
         let mut runner_instance = BuildRunner::new(backend, Some(cache))
             .with_jobs(jobs)
             .with_force(force)
@@ -1057,7 +1068,10 @@ fn parse_p1689_imports(json_str: &str) -> Result<Vec<String>, CmodError> {
 }
 
 /// Set up the Clang compiler backend from config.
-fn setup_compiler(config: &Config, activated_features: &[String]) -> (ClangBackend, String) {
+fn setup_compiler(
+    config: &Config,
+    activated_features: &[String],
+) -> (BackendConfig, Compiler, String) {
     let cxx_standard = config
         .manifest
         .toolchain
@@ -1065,24 +1079,31 @@ fn setup_compiler(config: &Config, activated_features: &[String]) -> (ClangBacke
         .and_then(|tc| tc.cxx_standard.clone())
         .unwrap_or_else(|| "20".to_string());
 
-    let mut backend = ClangBackend::new(&cxx_standard, config.profile);
+    let compiler_kind = config
+        .manifest
+        .toolchain
+        .as_ref()
+        .and_then(|tc| tc.compiler.clone())
+        .unwrap_or(Compiler::Clang);
+
+    let mut backend_cfg = BackendConfig {
+        cxx_standard,
+        profile: config.profile,
+        ..Default::default()
+    };
 
     if let Some(ref tc) = config.manifest.toolchain {
-        if let Some(ref stdlib) = tc.stdlib {
-            backend.stdlib = Some(stdlib.clone());
-        }
-        if let Some(ref sysroot) = tc.sysroot {
-            backend.sysroot = Some(sysroot.clone());
-        }
+        backend_cfg.stdlib = tc.stdlib.clone();
+        backend_cfg.sysroot = tc.sysroot.clone();
     }
 
     // Apply build section settings from manifest
     if let Some(ref build) = config.manifest.build {
         if build.lto == Some(true) {
-            backend.lto = true;
+            backend_cfg.lto = true;
         }
         if let Some(opt) = build.optimization {
-            backend.optimization = Some(opt);
+            backend_cfg.optimization = Some(opt);
         }
     }
 
@@ -1098,7 +1119,7 @@ fn setup_compiler(config: &Config, activated_features: &[String]) -> (ClangBacke
         })
         .unwrap_or_else(default_target);
 
-    backend.target = Some(target.clone());
+    backend_cfg.target = Some(target.clone());
 
     // Add feature flags as compiler defines
     for feature in activated_features {
@@ -1106,7 +1127,7 @@ fn setup_compiler(config: &Config, activated_features: &[String]) -> (ClangBacke
             "-DCMOD_FEATURE_{}=1",
             feature.to_uppercase().replace('-', "_")
         );
-        backend.extra_flags.push(flag);
+        backend_cfg.extra_flags.push(flag);
     }
 
     // Add include directories from [build] section
@@ -1114,21 +1135,21 @@ fn setup_compiler(config: &Config, activated_features: &[String]) -> (ClangBacke
         let root = &config.root;
         for dir in &build.include_dirs {
             let abs = root.join(dir);
-            backend.extra_flags.push(format!("-I{}", abs.display()));
+            backend_cfg.extra_flags.push(format!("-I{}", abs.display()));
         }
-        backend.extra_flags.extend(build.extra_flags.clone());
+        backend_cfg.extra_flags.extend(build.extra_flags.clone());
     }
 
     // Auto-detect include/ directory (convention)
     let include_dir = config.root.join("include");
     if include_dir.is_dir() {
         let flag = format!("-I{}", include_dir.display());
-        if !backend.extra_flags.contains(&flag) {
-            backend.extra_flags.push(flag);
+        if !backend_cfg.extra_flags.contains(&flag) {
+            backend_cfg.extra_flags.push(flag);
         }
     }
 
-    (backend, target)
+    (backend_cfg, compiler_kind, target)
 }
 
 /// Resolve which features are activated for the build.

--- a/crates/cmod-cli/src/commands/compile_commands.rs
+++ b/crates/cmod-cli/src/commands/compile_commands.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use cmod_build::compiler::ClangBackend;
+use cmod_build::compiler::{make_backend, BackendConfig};
 use cmod_build::graph::{ModuleGraph, ModuleNode};
 use cmod_build::plan::BuildPlan;
 use cmod_build::runner;
@@ -38,7 +38,7 @@ pub fn run(shell: &Shell, target_override: Option<String>) -> Result<(), CmodErr
         .and_then(|b| b.build_type)
         .unwrap_or_default();
 
-    let (mut backend, target) = setup_compiler(&config);
+    let (mut backend_cfg, compiler_kind, target) = setup_compiler(&config);
 
     // Add dependency artifacts if lockfile exists (without building)
     if let Ok(lockfile) = cmod_core::lockfile::Lockfile::load(&config.lockfile_path) {
@@ -46,16 +46,21 @@ pub fn run(shell: &Shell, target_override: Option<String>) -> Result<(), CmodErr
 
         // Add dep PCMs as -fmodule-file= flags
         for (mod_name, pcm_path) in &dep_artifacts.pcms {
-            backend
-                .extra_flags
-                .push(format!("-fmodule-file={}={}", mod_name, pcm_path.display()));
+            backend_cfg.extra_flags.push(format!(
+                "-fmodule-file={}={}",
+                mod_name,
+                pcm_path.display()
+            ));
         }
 
         // Add dep include directories
         for inc_dir in &dep_artifacts.include_dirs {
-            backend.extra_flags.push(format!("-I{}", inc_dir.display()));
+            backend_cfg
+                .extra_flags
+                .push(format!("-I{}", inc_dir.display()));
         }
     }
+    let backend = make_backend(compiler_kind, &backend_cfg)?;
 
     let plan = BuildPlan::from_graph(
         &graph,
@@ -66,7 +71,7 @@ pub fn run(shell: &Shell, target_override: Option<String>) -> Result<(), CmodErr
         Some(&config.manifest.package.name),
     )?;
 
-    let commands = plan.compile_commands(&backend, &config.root);
+    let commands = plan.compile_commands(backend.as_ref(), &config.root);
     let json = serde_json::to_string_pretty(&commands).map_err(|e| CmodError::BuildFailed {
         reason: format!("failed to serialize compile_commands.json: {}", e),
     })?;
@@ -146,8 +151,8 @@ fn extract_imports_from_source(path: &std::path::Path) -> Result<Vec<String>, Cm
     Ok(imports)
 }
 
-/// Set up the Clang compiler backend from config (same logic as build.rs).
-fn setup_compiler(config: &Config) -> (ClangBackend, String) {
+/// Assemble the compiler configuration from the manifest (same logic as build.rs).
+fn setup_compiler(config: &Config) -> (BackendConfig, cmod_core::types::Compiler, String) {
     let cxx_standard = config
         .manifest
         .toolchain
@@ -155,15 +160,22 @@ fn setup_compiler(config: &Config) -> (ClangBackend, String) {
         .and_then(|tc| tc.cxx_standard.clone())
         .unwrap_or_else(|| "20".to_string());
 
-    let mut backend = ClangBackend::new(&cxx_standard, config.profile);
+    let compiler_kind = config
+        .manifest
+        .toolchain
+        .as_ref()
+        .and_then(|tc| tc.compiler.clone())
+        .unwrap_or(cmod_core::types::Compiler::Clang);
+
+    let mut backend_cfg = BackendConfig {
+        cxx_standard,
+        profile: config.profile,
+        ..Default::default()
+    };
 
     if let Some(ref tc) = config.manifest.toolchain {
-        if let Some(ref stdlib) = tc.stdlib {
-            backend.stdlib = Some(stdlib.clone());
-        }
-        if let Some(ref sysroot) = tc.sysroot {
-            backend.sysroot = Some(sysroot.clone());
-        }
+        backend_cfg.stdlib = tc.stdlib.clone();
+        backend_cfg.sysroot = tc.sysroot.clone();
     }
 
     // Add include directories from [build] section
@@ -171,9 +183,9 @@ fn setup_compiler(config: &Config) -> (ClangBackend, String) {
         let root = &config.root;
         for dir in &build.include_dirs {
             let abs = root.join(dir);
-            backend.extra_flags.push(format!("-I{}", abs.display()));
+            backend_cfg.extra_flags.push(format!("-I{}", abs.display()));
         }
-        backend.extra_flags.extend(build.extra_flags.clone());
+        backend_cfg.extra_flags.extend(build.extra_flags.clone());
     }
 
     let target = config
@@ -188,9 +200,9 @@ fn setup_compiler(config: &Config) -> (ClangBackend, String) {
         })
         .unwrap_or_else(default_target);
 
-    backend.target = Some(target.clone());
+    backend_cfg.target = Some(target.clone());
 
-    (backend, target)
+    (backend_cfg, compiler_kind, target)
 }
 
 /// Detect the default target triple for the current platform.

--- a/crates/cmod-cli/tests/cli_integration.rs
+++ b/crates/cmod-cli/tests/cli_integration.rs
@@ -1264,6 +1264,29 @@ fn test_graph_critical_path_flag() {
     );
 }
 
+/// Regression test for #47: `[toolchain] compiler = "gcc"` must produce a
+/// clear not-implemented error instead of silently building with clang.
+#[test]
+fn test_build_with_gcc_compiler_errors_clearly() {
+    let tmp = TempDir::new().unwrap();
+    run_cmod(tmp.path(), &["init", "--name", "gccwanted"]);
+    let manifest = fs::read_to_string(tmp.path().join("cmod.toml")).unwrap();
+    fs::write(
+        tmp.path().join("cmod.toml"),
+        manifest.replace("compiler = \"clang\"", "compiler = \"gcc\""),
+    )
+    .unwrap();
+
+    let output = run_cmod(tmp.path(), &["build"]);
+    assert!(!output.status.success(), "gcc build must not succeed yet");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("not yet implemented"),
+        "expected a clear not-implemented error, got: {}",
+        stderr
+    );
+}
+
 /// Regression test for #45: `[cache] auth_token_env` must be honored by
 /// `cache push` — the bearer token from the environment goes on the wire.
 #[test]


### PR DESCRIPTION
## Summary

Closes #47 — the GCC-backend groundwork. A `GccBackend` can now be added as a sibling of `ClangBackend` by implementing one trait and adding one factory arm; nothing else in the build pipeline knows the concrete type.

**Structural changes**
- `BackendConfig` (all codegen knobs) + `make_backend(Compiler, &BackendConfig) -> Result<Box<dyn CompilerBackend>>` factory in `cmod-build::compiler`
- `CompilerBackend` grows the accessors the runner used to reach via public fields (`kind`, `compiler_path`, `version`, `cxx_standard`, `target`, `common_flags`, `fingerprint`) and is now `Send + Sync`
- `BuildRunner` holds `Box<dyn CompilerBackend>`; `BuildPlan::compile_commands` takes `&dyn CompilerBackend`
- Both CLI `setup_compiler`s assemble a `BackendConfig` and construct through the factory

**Behavioral changes (all deliberate)**
1. `[toolchain] compiler = "gcc"` (or `"msvc"`) now fails fast with `the gcc backend is not yet implemented; set [toolchain] compiler = "clang" … see issue #47` — previously the setting was **silently ignored** and clang was used
2. Cache keys derive from the backend `fingerprint()`, which covers LTO mode, optimization level, and sysroot — **previously missing from cache keys**, so e.g. toggling `lto` could reuse stale artifacts. One-time cache invalidation on upgrade
3. `compile_commands.json` records the resolved compiler path (e.g. `/opt/homebrew/opt/llvm@18/bin/clang++`) instead of the literal `clang++`

## Tests (TDD)

Six new tests written first and watched fail (E0425/E0422): factory returns Clang/errors on gcc+msvc, `BackendConfig` knobs reach `common_flags`, fingerprint determinism and sensitivity, plus integration `test_build_with_gcc_compiler_errors_clearly` pinning behavioral change #1 through the real binary.

## Validation

Full suite: 851 passed, 0 failed. Clippy (1.97) and fmt clean. End-to-end on a real project: `cmod build` compiles and links through the boxed backend; `cmod compile-commands` emits valid JSON with the resolved compiler path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)