### PR TITLE
feat(dev): git hooks for fmt (pre-commit) and clippy (pre-push)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,12 @@
+#!/bin/sh
+# cmod pre-commit hook: fast formatting gate.
+# Enable with:  git config core.hooksPath .githooks
+set -e
+
+echo "pre-commit: cargo fmt --all --check"
+if ! cargo fmt --all --check; then
+    echo ""
+    echo "pre-commit: formatting check failed — run 'cargo fmt --all' and re-stage."
+    echo "            (bypass once with 'git commit --no-verify')"
+    exit 1
+fi

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,16 @@
+#!/bin/sh
+# cmod pre-push hook: lint gate matching the Clippy CI job.
+# Enable with:  git config core.hooksPath .githooks
+#
+# Runs on push (not commit) because a full clippy pass takes a minute —
+# and the incidents this guards against (red clippy on main, PR #31 and
+# #37) both reached the repo via push.
+set -e
+
+echo "pre-push: cargo clippy --all-targets -- -D warnings"
+if ! cargo clippy --all-targets -- -D warnings; then
+    echo ""
+    echo "pre-push: clippy failed — fix the lints above before pushing."
+    echo "          (bypass once with 'git push --no-verify')"
+    exit 1
+fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,12 @@ git clone https://github.com/satishbabariya/cmod.git
 cd cmod
 cargo build
 cargo test
+git config core.hooksPath .githooks   # enable the fmt/clippy git hooks (recommended)
 ```
+
+The hooks mirror CI's gates: `pre-commit` runs `cargo fmt --all --check`
+(fast), `pre-push` runs `cargo clippy --all-targets -- -D warnings`. Bypass a
+single run with `--no-verify` if you must; CI still enforces both.
 
 ## Development Commands
 


### PR DESCRIPTION
## Summary

Closes #50 — local gates matching CI, as plain `.githooks/` shell scripts (no lefthook: zero dependencies for contributors, nothing to install).

- **pre-commit**: `cargo fmt --all --check` — fast, runs every commit
- **pre-push**: `cargo clippy --all-targets -- -D warnings` — the expensive check runs where it matters: both red-clippy incidents (the #31 aftermath fixed in #32, and the toolchain-drift lints fixed in #37) reached the repo via push, not commit

Opt-in per clone with `git config core.hooksPath .githooks` (git provides no safe auto-enable), documented in CONTRIBUTING's Getting Started. Each hook prints a fix hint and the `--no-verify` escape hatch; CI remains the enforcement of record.

## Verification

Exercised for real, not just written: a deliberately misformatted commit was **blocked** by pre-commit with the hint text; the clean commit passed through it; and the push of this very branch ran the pre-push clippy gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)