### PR TITLE
ci: cross-target smoke tests for --target plumbing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,3 +110,15 @@ jobs:
       - uses: dtolnay/rust-toolchain@1.80
       - uses: Swatinem/rust-cache@v2
       - run: cargo check --all
+
+  cross-target:
+    name: Cross-target smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      # Plan-level cross-compilation checks: --target with a non-host triple
+      # must flow into the build plan and emitted compiler flags (#54).
+      # No cross toolchain is installed — nothing is compiled.
+      - run: cargo test --test cli_integration test_cross_target -- --nocapture

--- a/crates/cmod-cli/tests/cli_integration.rs
+++ b/crates/cmod-cli/tests/cli_integration.rs
@@ -889,6 +889,60 @@ fn test_workspace_add_scaffold() {
     );
 }
 
+/// Cross-compilation smoke tests (#54): `--target` with a non-host triple
+/// must flow through plan generation and into emitted compiler flags.
+/// No cross toolchain is required — nothing is compiled.
+#[test]
+fn test_cross_target_compile_commands_flags() {
+    let cross_triple = if cfg!(target_arch = "aarch64") {
+        "x86_64-unknown-linux-gnu"
+    } else {
+        "aarch64-unknown-linux-gnu"
+    };
+
+    let tmp = TempDir::new().unwrap();
+    run_cmod(tmp.path(), &["init", "--name", "crosscc"]);
+
+    let output = run_cmod(tmp.path(), &["compile-commands", "--target", cross_triple]);
+    assert!(
+        output.status.success(),
+        "compile-commands --target failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json = fs::read_to_string(tmp.path().join("compile_commands.json")).unwrap();
+    assert!(
+        json.contains(&format!("--target={}", cross_triple)),
+        "expected --target={} in compile_commands.json",
+        cross_triple
+    );
+}
+
+#[test]
+fn test_cross_target_plan_generation() {
+    let cross_triple = if cfg!(target_arch = "aarch64") {
+        "x86_64-unknown-linux-gnu"
+    } else {
+        "aarch64-unknown-linux-gnu"
+    };
+
+    let tmp = TempDir::new().unwrap();
+    run_cmod(tmp.path(), &["init", "--name", "crossplan"]);
+
+    let output = run_cmod(tmp.path(), &["plan", "--target", cross_triple]);
+    assert!(
+        output.status.success(),
+        "plan --target failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.trim_start().starts_with('['),
+        "plan should emit a JSON node array, got: {}",
+        &stdout[..stdout.len().min(120)]
+    );
+}
+
 #[test]
 fn test_resolve_with_target_flag() {
     let tmp = TempDir::new().unwrap();


### PR DESCRIPTION
## Summary

Closes #54 (stretch) — `--target` existed but was never exercised in CI with a non-host triple.

- `test_cross_target_compile_commands_flags`: `cmod compile-commands --target <cross-triple>` emits `--target=<triple>` into `compile_commands.json` (the triple is chosen relative to the host arch, so it's a genuine cross triple on every matrix leg)
- `test_cross_target_plan_generation`: `cmod plan --target <cross-triple>` produces the JSON node array
- New visible `Cross-target smoke` CI job on ubuntu runs exactly these; the existing Test matrix also runs them on all 6 OS/toolchain legs

Scope note per the issue ("cross-checks, or at least plan-checks"): these are plan-level checks — no cross sysroot/toolchain is installed and nothing is compiled, which keeps the job fast and hermetic. Actual cross *builds* in CI would need a sysroot story first.

## Validation

Both tests pass locally (and were manually cross-checked against real output before writing). Full suite: 857 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)