### PR TITLE
docs: design doc for cmod search against a real index

### DIFF
--- a/docs/plan-search-registry.md
+++ b/docs/plan-search-registry.md
@@ -1,0 +1,83 @@
+# Design Doc: `cmod search` Against a Real Index
+
+**Status:** Designed 2026-07 (issue #53). Implementation is deliberately
+deferred — this document records what exists, what is missing, and the
+phased path to a live index. Companion to
+[plan-crates-io-publishing.md](plan-crates-io-publishing.md) and RFC-0015
+(ecosystem governance).
+
+## What already exists (more than the issue assumed)
+
+The code side of a Git-hosted registry is implemented and tested in
+`crates/cmod-resolver/src/registry.rs`:
+
+- **Index format**: `RegistryIndex` — one JSON document containing
+  `RegistryEntry` records (name, description, keywords, repository,
+  versions with yank flags). Serialized/loaded via `load`/`save`.
+- **Client**: `RegistryClient` clones/pulls the index repo into the local
+  cache dir; `cmod search` queries local deps + lockfile first, then the
+  remote index, with a cached-index fallback under `--offline`.
+- **Publish path**: `cmod publish` with `[publish] registry = "<url>"`
+  appends the released version to the module's entry.
+- **Governance**: `GovernancePolicy` + `NamingRules` +
+  `validate_for_publishing` (semver validity, license presence, banned
+  names); search already excludes deprecated modules.
+
+## What is missing
+
+1. **The index repo itself.** `RegistryClient::default_url()` points at
+   `https://github.com/cmod-registry/index`, which does not exist. Every
+   default-configuration `cmod search` quietly falls back to local results.
+2. **A submission path for non-owners.** `publish_module` pushes directly —
+   fine for a single maintainer, wrong for community submissions.
+3. **Scale/abuse story** — irrelevant until 1 and 2 exist.
+
+## Design
+
+### Hosting and identity
+
+- Claim the **`cmod-registry` GitHub org** (or fall back to
+  `satishbabariya/cmod-index` and update `default_url()` — one-line change).
+  The org form is preferred: it survives a repo transfer and matches the
+  URL already baked into released binaries.
+- The index repo contains `index.json` plus a `POLICY.md` derived from
+  `GovernancePolicy` defaults.
+
+### Index format v1
+
+Keep the existing single-file `RegistryIndex` JSON — it is implemented,
+tested, and fine for hundreds of modules. Record a `schema_version` field
+now (additive) so v2 sharding can be detected by old clients.
+
+### Submission flow (phase 2)
+
+PR-based, mirroring how Homebrew/winget operate at small scale:
+
+1. Publisher runs `cmod publish`; with no direct push rights the client
+   emits the JSON fragment and a link to open a PR against the index repo.
+2. A GitHub Action on the index repo runs the same
+   `validate_for_publishing` rules (naming, semver, license) plus a
+   reachability check of the module's Git URL + tag.
+3. Maintainer merge = listing. Yanks are PRs flipping the `yanked` flag —
+   never row deletion, so lockfiles keep resolving.
+
+### Scale path (phase 3, when needed)
+
+Single JSON → shard by first path segment of the module name
+(`index/github.com/f*.json`), the crates.io-index pattern. The
+`schema_version` bump plus a client update handles migration; not worth
+building before the index has ~1k entries.
+
+## Phased plan
+
+| Phase | Work | Size |
+|---|---|---|
+| 1 — bootstrap | Create the index repo (empty index + POLICY.md), verify `cmod search`/`publish` round-trip against it, add `schema_version` | small; unblocks everything |
+| 2 — submissions | PR-template + validation Action; `cmod publish` emits PR fragment when direct push fails | medium |
+| 3 — scale | Sharded index, client support | deferred until needed |
+
+## Owner decisions required before phase 1
+
+- [ ] Claim `cmod-registry` org vs. change `default_url()` to a personal repo
+- [ ] Moderation stance for name disputes (RFC-0015 has the framework;
+      POLICY.md must state who decides)


### PR DESCRIPTION
## Summary

Closes #53 (stretch) — the design doc the issue said must precede any code, as `docs/plan-search-registry.md`.

**Key finding:** far more exists than the issue assumed. The index format (`RegistryIndex` JSON), client (clone/pull with offline cache fallback), publish path, and governance validation are all implemented and tested in `cmod-resolver::registry`. The missing piece is not code — it's the **index repo itself**: `default_url()` points at `https://github.com/cmod-registry/index`, which doesn't exist, so every default `cmod search` silently falls back to local results.

The design therefore focuses on operations, not architecture: bootstrap the repo (phase 1, small — unblocks the whole feature), PR-based community submissions validated by a GitHub Action running the existing `validate_for_publishing` rules (phase 2), and crates.io-style index sharding deferred until ~1k entries (phase 3). Yanks flip a flag rather than delete rows so lockfiles keep resolving.

Two owner decisions are flagged before phase 1 can start: claiming the `cmod-registry` org (vs. a one-line `default_url` change to a personal repo) and the moderation stance for POLICY.md.

Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)