### PR TITLE
feat(build): wire CompilerBackend::bmi_extension through BuildPlan

### DIFF
--- a/crates/cmod-build/src/plan.rs
+++ b/crates/cmod-build/src/plan.rs
@@ -53,6 +53,7 @@ impl BuildPlan {
         profile: Profile,
         build_type: BuildType,
         package_name: Option<&str>,
+        bmi_ext: &str,
     ) -> Result<Self, CmodError> {
         let order = graph.topological_order()?;
         let mut nodes = Vec::new();
@@ -72,7 +73,8 @@ impl BuildPlan {
             match graph_node.kind {
                 cmod_core::types::ModuleUnitKind::InterfaceUnit
                 | cmod_core::types::ModuleUnitKind::PartitionUnit => {
-                    let pcm_path = pcm_dir.join(format!("{}.pcm", sanitize_name(module_name)));
+                    let pcm_path =
+                        pcm_dir.join(format!("{}.{}", sanitize_name(module_name), bmi_ext));
                     let obj_path = obj_dir.join(format!("{}.o", sanitize_name(module_name)));
 
                     // Dependencies are the PCM build nodes for imported modules
@@ -339,6 +341,40 @@ mod tests {
     use cmod_core::types::ModuleUnitKind;
 
     #[test]
+    fn test_build_plan_bmi_extension_flows_into_outputs() {
+        // #75: a non-Clang backend's BMI extension must shape plan outputs.
+        let mut graph = ModuleGraph::new();
+        graph.add_node(ModuleNode {
+            id: "m".to_string(),
+            name: "m".to_string(),
+            kind: ModuleUnitKind::InterfaceUnit,
+            source: PathBuf::from("src/m.ixx"),
+            package: "test".to_string(),
+            imports: vec![],
+            partition_of: None,
+        });
+
+        let plan = BuildPlan::from_graph(
+            &graph,
+            &PathBuf::from("/tmp/build"),
+            "x86_64-pc-windows-msvc",
+            Profile::Debug,
+            BuildType::Binary,
+            None,
+            "ifc",
+        )
+        .unwrap();
+
+        let bmi = plan.pcm_paths().get("m").cloned().expect("bmi path");
+        assert_eq!(bmi.extension().and_then(|e| e.to_str()), Some("ifc"));
+        // Objects keep their extension regardless of BMI format
+        assert!(plan
+            .object_paths()
+            .iter()
+            .all(|o| o.extension().and_then(|e| e.to_str()) == Some("o")));
+    }
+
+    #[test]
     fn test_build_plan_single_module() {
         let mut graph = ModuleGraph::new();
         graph.add_node(ModuleNode {
@@ -358,6 +394,7 @@ mod tests {
             Profile::Debug,
             BuildType::Binary,
             None,
+            "pcm",
         )
         .unwrap();
 
@@ -396,6 +433,7 @@ mod tests {
             Profile::Debug,
             BuildType::Binary,
             None,
+            "pcm",
         )
         .unwrap();
 
@@ -430,6 +468,7 @@ mod tests {
             Profile::Debug,
             BuildType::Binary,
             None,
+            "pcm",
         )
         .unwrap();
 
@@ -465,6 +504,7 @@ mod tests {
             Profile::Release,
             BuildType::StaticLib,
             None,
+            "pcm",
         )
         .unwrap();
 
@@ -501,6 +541,7 @@ mod tests {
             Profile::Debug,
             BuildType::SharedLib,
             None,
+            "pcm",
         )
         .unwrap();
 
@@ -542,6 +583,7 @@ mod tests {
             Profile::Debug,
             BuildType::Binary,
             None,
+            "pcm",
         )
         .unwrap();
 
@@ -577,6 +619,7 @@ mod tests {
             Profile::Debug,
             BuildType::Binary,
             None,
+            "pcm",
         )
         .unwrap();
 
@@ -614,6 +657,7 @@ mod tests {
             Profile::Debug,
             BuildType::Binary,
             None,
+            "pcm",
         )
         .unwrap();
 
@@ -658,6 +702,7 @@ mod tests {
             Profile::Debug,
             BuildType::Binary,
             None,
+            "pcm",
         )
         .unwrap();
 
@@ -712,6 +757,7 @@ mod tests {
             Profile::Debug,
             BuildType::Binary,
             None,
+            "pcm",
         )
         .unwrap();
 
@@ -761,6 +807,7 @@ mod tests {
             Profile::Debug,
             BuildType::Binary,
             None,
+            "pcm",
         )
         .unwrap();
 
@@ -796,6 +843,7 @@ mod tests {
             Profile::Debug,
             BuildType::Binary,
             None,
+            "pcm",
         )
         .unwrap();
 
@@ -828,6 +876,7 @@ mod tests {
             Profile::Debug,
             BuildType::Binary,
             None,
+            "pcm",
         )
         .unwrap();
 
@@ -862,6 +911,7 @@ mod tests {
             Profile::Release,
             BuildType::StaticLib,
             Some("my-library"),
+            "pcm",
         )
         .unwrap();
 
@@ -904,6 +954,7 @@ mod tests {
             Profile::Debug,
             BuildType::Binary,
             None,
+            "pcm",
         )
         .unwrap();
 

--- a/crates/cmod-build/src/runner.rs
+++ b/crates/cmod-build/src/runner.rs
@@ -283,8 +283,15 @@ impl BuildRunner {
         graph.validate()?;
 
         // Generate the build plan
-        let plan =
-            BuildPlan::from_graph(graph, build_dir, target, profile, build_type, package_name)?;
+        let plan = BuildPlan::from_graph(
+            graph,
+            build_dir,
+            target,
+            profile,
+            build_type,
+            package_name,
+            self.backend.bmi_extension(),
+        )?;
 
         // Ensure output directories exist
         fs::create_dir_all(build_dir.join("pcm"))?;
@@ -306,8 +313,15 @@ impl BuildRunner {
         package_name: Option<&str>,
     ) -> Result<(PathBuf, BuildStats), CmodError> {
         graph.validate()?;
-        let plan =
-            BuildPlan::from_graph(graph, build_dir, target, profile, build_type, package_name)?;
+        let plan = BuildPlan::from_graph(
+            graph,
+            build_dir,
+            target,
+            profile,
+            build_type,
+            package_name,
+            self.backend.bmi_extension(),
+        )?;
         fs::create_dir_all(build_dir.join("pcm"))?;
         fs::create_dir_all(build_dir.join("obj"))?;
         self.execute_plan(&plan)

--- a/crates/cmod-cli/src/commands/build.rs
+++ b/crates/cmod-cli/src/commands/build.rs
@@ -245,6 +245,7 @@ fn build_module(
 
     // Execute the build
     let build_dir = config.build_dir();
+
     let build_type = config
         .manifest
         .build
@@ -1508,6 +1509,10 @@ pub fn plan(shell: &Shell, target_override: Option<String>) -> Result<(), CmodEr
         .unwrap_or_else(default_target);
 
     let build_dir = config.build_dir();
+    // Resolve the configured backend so plan output reflects its BMI naming
+    // (and gcc/msvc fail fast, consistent with `cmod build`).
+    let (plan_backend_cfg, plan_compiler_kind, _) = setup_compiler(&config, &[]);
+    let plan_backend = cmod_build::compiler::make_backend(plan_compiler_kind, &plan_backend_cfg)?;
     let build_type = config
         .manifest
         .build
@@ -1570,6 +1575,7 @@ pub fn plan(shell: &Shell, target_override: Option<String>) -> Result<(), CmodEr
                     config.profile,
                     dep_build_type,
                     Some(&dep_config.manifest.package.name),
+                    plan_backend.bmi_extension(),
                 ) {
                     all_plan_nodes.extend(dep_plan.nodes);
                 }
@@ -1586,6 +1592,7 @@ pub fn plan(shell: &Shell, target_override: Option<String>) -> Result<(), CmodEr
         config.profile,
         build_type,
         Some(&config.manifest.package.name),
+        plan_backend.bmi_extension(),
     )?;
     all_plan_nodes.extend(plan.nodes);
 

--- a/crates/cmod-cli/src/commands/compile_commands.rs
+++ b/crates/cmod-cli/src/commands/compile_commands.rs
@@ -69,6 +69,7 @@ pub fn run(shell: &Shell, target_override: Option<String>) -> Result<(), CmodErr
         config.profile,
         build_type,
         Some(&config.manifest.package.name),
+        backend.bmi_extension(),
     )?;
 
     let commands = plan.compile_commands(backend.as_ref(), &config.root);


### PR DESCRIPTION
## Summary

Closes #75 — the first alpha.4 item and the declared unblocker for the GCC (#76) and MSVC (#77) backends.

`BuildPlan::from_graph` now takes `bmi_ext: &str`, so interface/partition node outputs carry the backend's BMI format (`.pcm` for clang, `.ifc` for msvc). Scope notes:

- The `pcm/` **directory name is deliberately unchanged** — only the file extension is format-specific; renaming the dir would churn caches and build state for zero value
- `pcm_paths()` and the runner's cache store/restore already operate on node outputs generically, so they follow automatically — the wiring is exactly the two hardcoded strings the #48 skeleton flagged
- `BuildRunner` passes `self.backend.bmi_extension()`; `cmod compile-commands` uses its constructed backend; **`cmod plan` now resolves the configured backend too**, which makes it fail fast on `compiler = "gcc"/"msvc"` — consistent with `cmod build` instead of happily planning clang-shaped output

## Tests (TDD)

`test_build_plan_bmi_extension_flows_into_outputs` written first, watched fail (E0061 — parameter didn't exist): a plan built with `"ifc"` yields `.ifc` BMI paths while objects stay `.o`. All existing plan tests pass `"pcm"` explicitly.

## Validation

858 passed, 0 failed. Clippy (1.97) and fmt clean. End-to-end: a real clang project builds with byte-identical `pcm/local_e2e.pcm` paths and `cmod plan` output unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)