### PR TITLE
ci: cut Windows cache-miss cost (sccache + line-tables-only)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,6 @@ env:
   # dramatically — the dominant cost of Windows link + cache steps (#80).
   CARGO_PROFILE_DEV_DEBUG: line-tables-only
   CARGO_PROFILE_TEST_DEBUG: line-tables-only
-  RUSTC_WRAPPER: sccache
-  SCCACHE_GHA_ENABLED: "true"
 
 jobs:
   fmt:
@@ -38,8 +36,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
-      - uses: mozilla-actions/sccache-action@v0.0.9
       - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: stable
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - run: cargo clippy --all-targets -- -D warnings
 
   test:
@@ -55,8 +55,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-      - uses: mozilla-actions/sccache-action@v0.0.9
       - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ${{ matrix.rust }}
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Install LLVM ${{ env.LLVM_VERSION }} (Ubuntu)
         if: runner.os == 'Linux'
         run: |
@@ -87,8 +89,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - uses: mozilla-actions/sccache-action@v0.0.9
       - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: stable
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Install LLVM ${{ env.LLVM_VERSION }} (Ubuntu)
         if: runner.os == 'Linux'
         run: |
@@ -117,8 +121,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@1.80
-      - uses: mozilla-actions/sccache-action@v0.0.9
       - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: stable
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - run: cargo check --all
 
   gcc-backend:
@@ -127,8 +133,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - uses: mozilla-actions/sccache-action@v0.0.9
       - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: stable
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Install g++-14
         run: sudo apt-get update && sudo apt-get install -y g++-14
       - name: Build cmod
@@ -151,8 +159,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - uses: mozilla-actions/sccache-action@v0.0.9
       - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: stable
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       # Plan-level cross-compilation checks: --target with a non-host triple
       # must flow into the build plan and emitted compiler flags (#54).
       # No cross toolchain is installed — nothing is compiled.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,12 @@ on:
 env:
   CARGO_TERM_COLOR: always
   LLVM_VERSION: "17"
+  # Line tables keep backtrace line numbers while cutting debuginfo size
+  # dramatically — the dominant cost of Windows link + cache steps (#80).
+  CARGO_PROFILE_DEV_DEBUG: line-tables-only
+  CARGO_PROFILE_TEST_DEBUG: line-tables-only
+  RUSTC_WRAPPER: sccache
+  SCCACHE_GHA_ENABLED: "true"
 
 jobs:
   fmt:
@@ -32,6 +38,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
+      - uses: mozilla-actions/sccache-action@v0.0.9
       - uses: Swatinem/rust-cache@v2
       - run: cargo clippy --all-targets -- -D warnings
 
@@ -48,6 +55,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
+      - uses: mozilla-actions/sccache-action@v0.0.9
       - uses: Swatinem/rust-cache@v2
       - name: Install LLVM ${{ env.LLVM_VERSION }} (Ubuntu)
         if: runner.os == 'Linux'
@@ -79,6 +87,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - uses: mozilla-actions/sccache-action@v0.0.9
       - uses: Swatinem/rust-cache@v2
       - name: Install LLVM ${{ env.LLVM_VERSION }} (Ubuntu)
         if: runner.os == 'Linux'
@@ -108,6 +117,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@1.80
+      - uses: mozilla-actions/sccache-action@v0.0.9
       - uses: Swatinem/rust-cache@v2
       - run: cargo check --all
 
@@ -117,6 +127,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - uses: mozilla-actions/sccache-action@v0.0.9
       - uses: Swatinem/rust-cache@v2
       - name: Install g++-14
         run: sudo apt-get update && sudo apt-get install -y g++-14
@@ -140,6 +151,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - uses: mozilla-actions/sccache-action@v0.0.9
       - uses: Swatinem/rust-cache@v2
       # Plan-level cross-compilation checks: --target with a non-host triple
       # must flow into the build plan and emitted compiler flags (#54).


### PR DESCRIPTION
## Summary

Closes #80 — grounded in timing data from recent runs:

| Leg | warm | cold |
|---|---|---|
| windows stable | **1m** | **8–10m** |
| windows nightly | ~2m | ~2m |
| ubuntu/macos stable | — | 2.5–4.5m |

The Windows matrix legs aren't inherently the long pole — **cache misses** are (every `Cargo.lock` change or fresh branch pays 8–10m of MSVC compile+PDB+link). So instead of trimming the matrix:

1. **`CARGO_PROFILE_{DEV,TEST}_DEBUG=line-tables-only`** — keeps line numbers in test backtraces while dramatically shrinking debuginfo, the dominant MSVC link + cache-archive cost
2. **sccache** (`mozilla-actions/sccache-action`, GHA cache backend) — per-compilation-unit caching that survives lockfile bumps and branch switches; installed in every ci.yml cargo job since `RUSTC_WRAPPER` is workflow-level (`CARGO_INCREMENTAL=0` was already set, which sccache requires)

**Nightly legs stay**: the issue asked whether they earn their keep — the data says they're cheap (~2m) and they're the canary that caught the clippy/toolchain drift class of failure (#37).

## Measurement plan

This PR's first run is a **cold** sccache baseline (expect no speedup, possibly slight overhead). I'll push a trivial follow-up commit to the PR to measure the warm-cache delta before merging, and post both numbers here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved continuous integration build performance and caching across supported platforms.
  * Updated validation workflows for linting, testing, end-to-end checks, compatibility checks, and cross-target builds.
  * No user-facing functionality changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->