### PR TITLE
fix(add): normalize full URLs to canonical bare dependency keys

### DIFF
--- a/crates/cmod-cli/src/commands/add.rs
+++ b/crates/cmod-cli/src/commands/add.rs
@@ -119,13 +119,20 @@ pub fn run(
 
 /// Parse a dependency specifier like `github.com/fmtlib/fmt@^10.2`.
 fn parse_dep_specifier(spec: &str) -> (String, Option<String>) {
-    if let Some(idx) = spec.find('@') {
-        let key = spec[..idx].to_string();
-        let version = spec[idx + 1..].to_string();
-        (key, Some(version))
+    let (raw_key, version) = if let Some(idx) = spec.find('@') {
+        (&spec[..idx], Some(spec[idx + 1..].to_string()))
     } else {
-        (spec.to_string(), None)
-    }
+        (spec, None)
+    };
+    // Normalize full URLs to the canonical bare key (`github.com/owner/repo`)
+    // so resolve_dep_url's scheme prepending never doubles up.
+    let key = raw_key
+        .trim_start_matches("https://")
+        .trim_start_matches("http://")
+        .trim_end_matches('/')
+        .trim_end_matches(".git")
+        .to_string();
+    (key, version)
 }
 
 /// Validate that a Git URL is reachable by attempting to list remote refs.
@@ -154,5 +161,33 @@ fn validate_git_url(url: &str) -> Result<(), CmodError> {
             }
         }
         Err(e) => Err(CmodError::Other(format!("failed to validate URL: {}", e))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Regression tests (#22 sweep): full URLs passed to `cmod add` must
+    /// normalize to the canonical bare key instead of producing
+    /// `https://https://…` at resolve time.
+    #[test]
+    fn test_parse_dep_specifier_strips_scheme() {
+        let (key, ver) = parse_dep_specifier("https://github.com/fmtlib/fmt");
+        assert_eq!(key, "github.com/fmtlib/fmt");
+        assert_eq!(ver, None);
+    }
+
+    #[test]
+    fn test_parse_dep_specifier_strips_dotgit_and_slash() {
+        let (key, _) = parse_dep_specifier("http://github.com/fmtlib/fmt.git/");
+        assert_eq!(key, "github.com/fmtlib/fmt");
+    }
+
+    #[test]
+    fn test_parse_dep_specifier_bare_with_version() {
+        let (key, ver) = parse_dep_specifier("github.com/fmtlib/fmt@^10.2");
+        assert_eq!(key, "github.com/fmtlib/fmt");
+        assert_eq!(ver.as_deref(), Some("^10.2"));
     }
 }

--- a/crates/cmod-core/src/manifest.rs
+++ b/crates/cmod-core/src/manifest.rs
@@ -673,15 +673,22 @@ impl Manifest {
     /// construct the full https URL. For detailed deps with an explicit `git` field,
     /// use that directly.
     pub fn resolve_dep_url(key: &str, dep: &Dependency) -> String {
-        match dep {
-            Dependency::Simple(_) => {
+        // Keys are canonically bare (`github.com/owner/repo`), but tolerate
+        // hand-edited manifests that already carry a scheme.
+        let to_url = |key: &str| {
+            if key.contains("://") {
+                key.to_string()
+            } else {
                 format!("https://{}", key)
             }
+        };
+        match dep {
+            Dependency::Simple(_) => to_url(key),
             Dependency::Detailed(d) => {
                 if let Some(git) = &d.git {
                     git.clone()
                 } else {
-                    format!("https://{}", key)
+                    to_url(key)
                 }
             }
         }


### PR DESCRIPTION
## Summary

Found by the #22 real-world validation sweep: `cmod add https://github.com/owner/repo` (the form every user will paste from a browser) stored the full URL as the manifest key, and `resolve_dep_url` unconditionally prepends `https://` — yielding `https://https://github.com/...` and failing every subsequent resolve with a DNS error on host `https`.

Two-layer fix:
- `parse_dep_specifier` normalizes to the canonical bare key: strips `https://`/`http://`, trailing `/`, and `.git` — so `cmod add https://github.com/x/y.git` behaves identically to `cmod add github.com/x/y`
- `resolve_dep_url` tolerates hand-edited manifests whose keys already contain a scheme (defense in depth)

## Tests (TDD)

Three unit tests written first (two watched fail with the doubled/unstripped keys): scheme stripping, `.git`+slash stripping, and the bare+version form staying intact. E2E verified with the sweep's exact failing command — `cmod add https://github.com/cmod-ecosystem/fmt --branch cmod-support` now resolves and writes the bare key.

Full suite: 864 passed, 0 failed. Clippy (1.97) and fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dependency URL handling for dependencies specified with `http://` or `https://`.
  * Prevented malformed URLs when dependency entries already include a URL scheme.
  * Normalized dependency identifiers by removing trailing slashes and `.git` suffixes.
  * Preserved optional version information when parsing dependency specifications.
  * Added coverage for URL-based dependencies, Git-style URLs, and versioned dependency keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->