### PR TITLE
feat(cache): verified remote restores + transfer-resilience design note

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -243,6 +243,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "sha2",
  "tempfile",
  "toml",
  "wait-timeout",

--- a/crates/cmod-build/src/runner.rs
+++ b/crates/cmod-build/src/runner.rs
@@ -411,29 +411,66 @@ impl BuildRunner {
 
         // Try remote cache on local miss
         if let Some(ref remote) = self.remote_cache {
-            let mut all_downloaded = true;
-            for output in &node.outputs {
-                let artifact_name = output
-                    .file_name()
-                    .and_then(|f| f.to_str())
-                    .unwrap_or("unknown");
+            // Fetch the entry's metadata first: downloaded artifacts are
+            // verified against its per-artifact hashes so a truncated
+            // server-side file (interrupted upload) is never used (#62).
+            let metadata = node.outputs.first().and_then(|first| {
+                let meta_path = first.with_file_name(".remote-metadata.json");
+                let fetched = remote
+                    .get(module_id, key, "metadata.json", &meta_path)
+                    .unwrap_or(false);
+                let parsed = if fetched {
+                    std::fs::read_to_string(&meta_path)
+                        .ok()
+                        .and_then(|s| serde_json::from_str::<ArtifactMetadata>(&s).ok())
+                } else {
+                    None
+                };
+                let _ = std::fs::remove_file(&meta_path);
+                parsed
+            });
 
-                match remote.get(module_id, key, artifact_name, output) {
-                    Ok(true) => {
-                        // Store locally for next time
-                        if let Some(ref cache) = self.cache {
-                            let name = artifact_name.to_string();
-                            let _ = cache.store_single_artifact(module_id, key, &name, output);
+            if let Some(metadata) = metadata {
+                let mut all_downloaded = true;
+                for output in &node.outputs {
+                    let artifact_name = output
+                        .file_name()
+                        .and_then(|f| f.to_str())
+                        .unwrap_or("unknown");
+
+                    match remote.get(module_id, key, artifact_name, output) {
+                        Ok(true) => {
+                            if !cmod_cache::artifact_matches_metadata(
+                                &metadata,
+                                artifact_name,
+                                output,
+                            ) {
+                                self.emit_verbose(
+                                    "Rejected",
+                                    format!(
+                                        "{}/{} failed hash verification; treating as miss",
+                                        module_id, artifact_name
+                                    ),
+                                );
+                                let _ = std::fs::remove_file(output);
+                                all_downloaded = false;
+                                break;
+                            }
+                            // Store locally for next time
+                            if let Some(ref cache) = self.cache {
+                                let name = artifact_name.to_string();
+                                let _ = cache.store_single_artifact(module_id, key, &name, output);
+                            }
+                        }
+                        _ => {
+                            all_downloaded = false;
+                            break;
                         }
                     }
-                    _ => {
-                        all_downloaded = false;
-                        break;
-                    }
                 }
-            }
-            if all_downloaded && !node.outputs.is_empty() {
-                return true;
+                if all_downloaded && !node.outputs.is_empty() {
+                    return true;
+                }
             }
         }
 

--- a/crates/cmod-cache/src/cache.rs
+++ b/crates/cmod-cache/src/cache.rs
@@ -697,6 +697,22 @@ pub struct CacheEntryBrief {
     pub size: u64,
 }
 
+/// Check a downloaded artifact against its metadata entry (SHA-256 + size).
+///
+/// Returns `false` when the artifact is not listed in the metadata or its
+/// content mismatches — the caller must treat the cache entry as a miss.
+/// This is what neutralizes truncated server-side files from interrupted
+/// uploads (#62 phase 1).
+pub fn artifact_matches_metadata(metadata: &ArtifactMetadata, name: &str, path: &Path) -> bool {
+    let Some(entry) = metadata.artifacts.iter().find(|a| a.name == name) else {
+        return false;
+    };
+    match (hash_file(path), fs::metadata(path)) {
+        (Ok(hash), Ok(meta)) => hash == entry.hash && meta.len() == entry.size,
+        _ => false,
+    }
+}
+
 /// Compress data using zstd.
 pub fn compress_zstd(data: &[u8]) -> Result<Vec<u8>, CmodError> {
     let mut encoder = zstd::Encoder::new(Vec::new(), 3).map_err(|e| CmodError::CacheError {
@@ -781,6 +797,70 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let cache = ArtifactCache::new(tmp.path().to_path_buf());
         (tmp, cache)
+    }
+
+    // --- remote-restore verification (#62 phase 1) ---
+
+    #[test]
+    fn test_artifact_matches_metadata_accepts_intact() {
+        let tmp = TempDir::new().unwrap();
+        let f = tmp.path().join("a.pcm");
+        std::fs::write(&f, b"bytes").unwrap();
+        let meta = ArtifactMetadata {
+            module_name: "m".into(),
+            cache_key: "k".into(),
+            source_hash: String::new(),
+            compiler: "clang".into(),
+            compiler_version: String::new(),
+            target: String::new(),
+            created_at: String::new(),
+            artifacts: vec![CachedArtifactEntry {
+                name: "a.pcm".into(),
+                hash: crate::key::hash_bytes(b"bytes"),
+                size: 5,
+            }],
+        };
+        assert!(artifact_matches_metadata(&meta, "a.pcm", &f));
+    }
+
+    #[test]
+    fn test_artifact_matches_metadata_rejects_truncated() {
+        let tmp = TempDir::new().unwrap();
+        let f = tmp.path().join("a.pcm");
+        std::fs::write(&f, b"byt").unwrap(); // truncated upload stump
+        let meta = ArtifactMetadata {
+            module_name: "m".into(),
+            cache_key: "k".into(),
+            source_hash: String::new(),
+            compiler: "clang".into(),
+            compiler_version: String::new(),
+            target: String::new(),
+            created_at: String::new(),
+            artifacts: vec![CachedArtifactEntry {
+                name: "a.pcm".into(),
+                hash: crate::key::hash_bytes(b"bytes"),
+                size: 5,
+            }],
+        };
+        assert!(!artifact_matches_metadata(&meta, "a.pcm", &f));
+    }
+
+    #[test]
+    fn test_artifact_matches_metadata_rejects_unknown_name() {
+        let tmp = TempDir::new().unwrap();
+        let f = tmp.path().join("a.pcm");
+        std::fs::write(&f, b"bytes").unwrap();
+        let meta = ArtifactMetadata {
+            module_name: "m".into(),
+            cache_key: "k".into(),
+            source_hash: String::new(),
+            compiler: "clang".into(),
+            compiler_version: String::new(),
+            target: String::new(),
+            created_at: String::new(),
+            artifacts: vec![],
+        };
+        assert!(!artifact_matches_metadata(&meta, "a.pcm", &f));
     }
 
     #[test]

--- a/crates/cmod-cache/src/lib.rs
+++ b/crates/cmod-cache/src/lib.rs
@@ -6,8 +6,8 @@ pub mod remote;
 
 pub use bmi::{export_bmi, import_bmi, BmiMetadata, BmiPackage};
 pub use cache::{
-    compress_zstd, decompress_zstd, parse_ttl, ArtifactCache, CacheEntryInfo, CacheStatusJson,
-    EvictionResult,
+    artifact_matches_metadata, compress_zstd, decompress_zstd, parse_ttl, ArtifactCache,
+    CacheEntryInfo, CacheStatusJson, EvictionResult,
 };
 pub use key::CacheKey;
 pub use remote::{HttpRemoteCache, RemoteCache, RemoteCacheConfig, RemoteCacheMode};

--- a/crates/cmod-cli/Cargo.toml
+++ b/crates/cmod-cli/Cargo.toml
@@ -39,3 +39,4 @@ glob = { workspace = true }
 wait-timeout = { workspace = true }
 
 [dev-dependencies]
+sha2 = { workspace = true }

--- a/crates/cmod-cli/src/commands/cache.rs
+++ b/crates/cmod-cli/src/commands/cache.rs
@@ -226,11 +226,15 @@ pub fn pull(remote_override: Option<String>, shell: &Shell) -> Result<(), CmodEr
                 let dest_dir = cache.entry_dir(&pkg.name, &key);
                 std::fs::create_dir_all(&dest_dir)?;
 
+                let mut downloaded: Vec<String> = Vec::new();
                 for artifact in &["module.pcm", "object.o", "metadata.json"] {
                     let dest = dest_dir.join(artifact);
                     match remote.get(&pkg.name, &key, artifact, &dest) {
                         Ok(true) => {
                             shell.verbose("Downloaded", format!("{}/{}", pkg.name, artifact));
+                            if *artifact != "metadata.json" {
+                                downloaded.push(artifact.to_string());
+                            }
                         }
                         Ok(false) => {}
                         Err(e) => {
@@ -238,7 +242,31 @@ pub fn pull(remote_override: Option<String>, shell: &Shell) -> Result<(), CmodEr
                         }
                     }
                 }
-                pulled += 1;
+
+                // Verify downloads against the entry's metadata hashes —
+                // truncated server-side files must never enter the local
+                // cache (#62 phase 1).
+                let verified = std::fs::read_to_string(dest_dir.join("metadata.json"))
+                    .ok()
+                    .and_then(|s| {
+                        serde_json::from_str::<cmod_cache::cache::ArtifactMetadata>(&s).ok()
+                    })
+                    .map(|meta| {
+                        downloaded.iter().all(|name| {
+                            cmod_cache::artifact_matches_metadata(&meta, name, &dest_dir.join(name))
+                        })
+                    })
+                    .unwrap_or(downloaded.is_empty());
+
+                if verified {
+                    pulled += 1;
+                } else {
+                    shell.warn(format!(
+                        "{} — remote artifacts failed hash verification; entry discarded",
+                        pkg.name
+                    ));
+                    let _ = std::fs::remove_dir_all(&dest_dir);
+                }
             }
             Ok(false) => {
                 shell.verbose("Missing", format!("{} — not in remote cache", pkg.name));

--- a/crates/cmod-cli/tests/cli_integration.rs
+++ b/crates/cmod-cli/tests/cli_integration.rs
@@ -1342,6 +1342,97 @@ fn test_build_with_msvc_compiler_errors_clearly() {
     );
 }
 
+/// #62 phase 1: `cache pull` must verify downloaded artifacts against the
+/// entry's metadata hashes and discard entries with truncated/corrupt
+/// server-side files (e.g. from an interrupted upload).
+#[test]
+fn test_cache_pull_rejects_corrupt_remote_artifact() {
+    use std::io::{Read, Write};
+
+    let tmp = TempDir::new().unwrap();
+    run_cmod(tmp.path(), &["init", "--name", "pullverify"]);
+
+    let key = "c".repeat(64);
+    let manifest = fs::read_to_string(tmp.path().join("cmod.toml")).unwrap();
+    fs::write(
+        tmp.path().join("cmod.toml"),
+        format!("{}\n[cache]\nlocal_path = \"localcache\"\n", manifest),
+    )
+    .unwrap();
+    fs::write(
+        tmp.path().join("cmod.lock"),
+        format!(
+            "version = 1\n\n[[package]]\nname = \"dep\"\nversion = \"1.0.0\"\nsource = \"git\"\nhash = \"{}\"\n",
+            key
+        ),
+    )
+    .unwrap();
+
+    // Server: metadata declares the hash of the *intact* pcm bytes, but the
+    // served pcm is a truncated stump.
+    let good_pcm: &[u8] = b"intact pcm bytes";
+    let good_obj: &[u8] = b"intact obj bytes";
+    let sha = |b: &[u8]| {
+        use sha2::{Digest, Sha256};
+        format!("{:x}", Sha256::digest(b))
+    };
+    let metadata = format!(
+        r#"{{"module_name":"dep","cache_key":"{key}","source_hash":"","compiler":"clang","compiler_version":"","target":"","created_at":"","artifacts":[{{"name":"module.pcm","hash":"{}","size":{}}},{{"name":"object.o","hash":"{}","size":{}}}]}}"#,
+        sha(good_pcm),
+        good_pcm.len(),
+        sha(good_obj),
+        good_obj.len(),
+    );
+
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+    std::thread::spawn(move || {
+        for stream in listener.incoming() {
+            let Ok(mut stream) = stream else { break };
+            let mut buf = [0u8; 4096];
+            let n = stream.read(&mut buf).unwrap_or(0);
+            let req = String::from_utf8_lossy(&buf[..n]).to_string();
+            let first = req.lines().next().unwrap_or("").to_string();
+            let body: Vec<u8> = if first.starts_with("HEAD") {
+                Vec::new()
+            } else if first.contains("metadata.json") {
+                metadata.clone().into_bytes()
+            } else if first.contains("module.pcm") {
+                b"stump".to_vec() // truncated upload leftovers
+            } else if first.contains("object.o") {
+                good_obj.to_vec()
+            } else {
+                let _ = stream.write_all(
+                    b"HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+                );
+                continue;
+            };
+            let _ = stream.write_all(
+                format!(
+                    "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                    body.len()
+                )
+                .as_bytes(),
+            );
+            let _ = stream.write_all(&body);
+        }
+    });
+
+    let output = run_cmod(
+        tmp.path(),
+        &["cache", "pull", "--remote", &format!("http://{}", addr)],
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("failed hash verification"),
+        "pull must reject the corrupt artifact, got: {}",
+        stderr
+    );
+    // The poisoned entry must not exist in the local cache
+    let entry = tmp.path().join("localcache").join("dep").join(&key);
+    assert!(!entry.exists(), "corrupt entry must be discarded");
+}
+
 /// Regression test for #45: `[cache] auth_token_env` must be honored by
 /// `cache push` — the bearer token from the environment goes on the wire.
 #[test]

--- a/docs/guide/remote-cache.md
+++ b/docs/guide/remote-cache.md
@@ -181,6 +181,15 @@ cmod cache clean                                   # drop the local cache
 cmod build --remote-cache http://127.0.0.1:8787   # restores from the server
 ```
 
+## Transfer resilience
+
+Downloads are atomic (`.part` + rename) and every remote restore is
+verified against the entry's `metadata.json` hashes — a truncated
+server-side file from an interrupted upload is treated as a cache miss,
+never used, never stored locally. Design rationale and the
+resumable-transfer roadmap live in
+[plan-remote-cache-resilience.md](../plan-remote-cache-resilience.md).
+
 ## Security notes
 
 - **Only trusted writers.** Anyone who can PUT can serve compiled objects to

--- a/docs/plan-remote-cache-resilience.md
+++ b/docs/plan-remote-cache-resilience.md
@@ -1,0 +1,69 @@
+# Design Note: Remote-Cache Resilience (Partial Transfers)
+
+**Status:** Decided 2026-07 (issue #62). Phase 1 implemented; phases 2–3
+recorded with explicit triggers.
+
+## The actual failure modes
+
+Issue #62 asked for "resumable/partial uploads." Examining the transfer
+paths shows three distinct concerns with very different costs:
+
+1. **Interrupted PUT leaves a truncated artifact on the server.** nginx's
+   `dav_methods PUT` writes in place — a disconnect mid-upload leaves a
+   partial file that later serves with `200`. This is a **correctness**
+   hole: a consumer restores a truncated PCM/object.
+2. **Interrupted GET.** The client buffers the whole body and writes
+   atomically (`.part` + rename, #63) — an interrupted download leaves
+   *nothing*; the existing retry (3 attempts, backoff) re-requests. There is
+   no partial state to resume, only wasted bytes on retry.
+3. **Upload resume for large artifacts.** Pure efficiency; matters only
+   when individual artifacts are large enough that restarting a PUT hurts
+   (≳100 MB — LTO objects in very large modules).
+
+Artifacts today are KB–MB scale (an entire example project's cache is
+~600 KB), so 2 and 3 are efficiency questions with no current pain, while
+1 corrupts builds *today* given one flaky uplink.
+
+## Decision
+
+### Phase 1 — verified restores (implemented)
+
+Every cache entry's `metadata.json` already records per-artifact SHA-256
+and size (`CachedArtifactEntry`). The remote-restore paths now use it:
+
+- the build runner fetches `metadata.json` before artifacts on a remote
+  hit and verifies each downloaded artifact's hash; any mismatch treats
+  the whole entry as a miss (partial server files are never used, never
+  stored locally);
+- `cmod cache pull` performs the same verification.
+
+This **neutralizes the harm of interrupted PUTs** with zero protocol or
+server changes: a truncated server artifact fails verification, the client
+compiles locally, and the next successful push overwrites the stump.
+
+### Phase 2 — streaming + Range resume for GET (deferred)
+
+Plain servers (nginx, Caddy) support `Range` natively, so download resume
+needs no protocol extension — but it requires switching from
+buffer-then-write to streaming-to-`.part`, keeping partials on network
+error, and `Range`-continuing on retry. **Trigger:** artifact sizes where
+re-downloading on retry is measurably painful (≳50–100 MB), i.e. large-scale
+LTO/monorepo adoption. Until then the added state machine is not worth it.
+
+### Phase 3 — resumable PUT (rejected for now)
+
+Every resumable-upload mechanism (TUS, S3-style multipart, chunk+finalize
+conventions) requires **server-side logic**, which breaks the project's
+"any static file server" promise from `docs/guide/remote-cache.md`. With
+phase 1 closing the correctness hole, an interrupted PUT costs only a
+retried upload. **Trigger to revisit:** a real deployment with individual
+artifacts ≳100 MB over unreliable links; the likely design then is an
+optional TUS extension negotiated via `OPTIONS`, keeping plain servers
+first-class.
+
+## Non-goals
+
+- WebDAV `MOVE`-based two-phase PUT (atomic server-side): tempting for
+  nginx, but unsupported by other backends and unverifiable by the client;
+  phase 1 verification covers the same failure at the consumer, which is
+  where it matters.


### PR DESCRIPTION
## Summary

Closes #62 — starting with the design note the issue asked for (`docs/plan-remote-cache-resilience.md`), which reframes the problem:

- **Interrupted PUT → truncated server file that serves as `200`** is a **correctness** hole (nginx dav writes in place) — a consumer restores a broken PCM today
- Interrupted **GET** leaves nothing to resume (downloads are buffered + atomically renamed since #63); retry already re-requests
- **Resume** (either direction) is pure efficiency, irrelevant at current artifact sizes (~KB–MB)

**Phase 1, implemented here:** every cache entry's `metadata.json` already carries per-artifact SHA-256 + size — remote restores now use it. The build runner fetches metadata before artifacts on a remote hit and verifies each download; `cmod cache pull` does the same and discards failed entries with a warning. Truncated server files are treated as misses — never used, never stored locally — which **neutralizes the harm of interrupted uploads with zero protocol/server changes**, preserving the "any static file server" guarantee.

**Phase 2** (streaming + `Range` GET resume — plain servers support it natively) and **phase 3** (resumable PUT — *rejected for now*: every mechanism needs server logic) are documented with explicit ≳50–100 MB artifact-size triggers.

## Tests (TDD)

- 3 unit tests for `artifact_matches_metadata` (intact / truncated / unknown-name), watched fail E0425
- Integration: `test_cache_pull_rejects_corrupt_remote_artifact` — an in-test HTTP server whose metadata declares the intact hash but serves a truncated stump; pull warns `failed hash verification` and the poisoned entry never lands in the local cache

Full suite: 868 passed, 0 failed. Clippy (1.97) + fmt clean. Guide updated with a Transfer Resilience section linking the note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)