### PR TITLE
fix(registry): push publications to the remote + registry phase 1 complete

### DIFF
--- a/crates/cmod-resolver/src/registry.rs
+++ b/crates/cmod-resolver/src/registry.rs
@@ -267,12 +267,85 @@ impl RegistryClient {
             index.upsert_module(entry);
         }
 
-        let index_path = self
-            .cache_dir
-            .join("registry")
-            .join("index")
-            .join("index.json");
+        let repo_path = self.cache_dir.join("registry").join("index");
+        let index_path = repo_path.join("index.json");
         index.save(&index_path)?;
+
+        // Commit and push the updated index — a publication that only edits
+        // the local cache clone is silently lost on the next pull (#78).
+        let repo = git2::Repository::open(&repo_path).map_err(|e| CmodError::GitError {
+            reason: format!("failed to open registry clone: {}", e),
+        })?;
+        let mut git_index = repo.index().map_err(|e| CmodError::GitError {
+            reason: format!("registry index: {}", e),
+        })?;
+        git_index
+            .add_path(Path::new("index.json"))
+            .and_then(|_| git_index.write())
+            .map_err(|e| CmodError::GitError {
+                reason: format!("failed to stage index.json: {}", e),
+            })?;
+        let tree_id = git_index.write_tree().map_err(|e| CmodError::GitError {
+            reason: format!("failed to write tree: {}", e),
+        })?;
+        let tree = repo.find_tree(tree_id).map_err(|e| CmodError::GitError {
+            reason: format!("tree lookup: {}", e),
+        })?;
+        let sig = repo
+            .signature()
+            .or_else(|_| git2::Signature::now("cmod", "cmod@localhost"))
+            .map_err(|e| CmodError::GitError {
+                reason: format!("signature: {}", e),
+            })?;
+        let head =
+            repo.head()
+                .and_then(|h| h.peel_to_commit())
+                .map_err(|e| CmodError::GitError {
+                    reason: format!("registry HEAD: {}", e),
+                })?;
+        let branch = repo
+            .head()
+            .ok()
+            .and_then(|h| h.shorthand().map(str::to_string))
+            .unwrap_or_else(|| "main".to_string());
+        repo.commit(
+            Some("HEAD"),
+            &sig,
+            &sig,
+            &format!("publish {} v{}", params.name, params.version),
+            &tree,
+            &[&head],
+        )
+        .map_err(|e| CmodError::GitError {
+            reason: format!("failed to commit registry update: {}", e),
+        })?;
+
+        let mut remote = repo
+            .find_remote("origin")
+            .map_err(|e| CmodError::GitError {
+                reason: format!("registry remote: {}", e),
+            })?;
+        let config = repo.config().map_err(|e| CmodError::GitError {
+            reason: format!("git config: {}", e),
+        })?;
+        let mut callbacks = git2::RemoteCallbacks::new();
+        callbacks.credentials(move |url, username, _| {
+            git2::Cred::credential_helper(&config, url, username).or_else(|_| git2::Cred::default())
+        });
+        let mut push_opts = git2::PushOptions::new();
+        push_opts.remote_callbacks(callbacks);
+        remote
+            .push(
+                &[&format!("refs/heads/{b}:refs/heads/{b}", b = branch)],
+                Some(&mut push_opts),
+            )
+            .map_err(|e| CmodError::GitError {
+                reason: format!(
+                    "failed to push registry update (write access to the registry \
+                     repository is required): {}",
+                    e
+                ),
+            })?;
 
         Ok(())
     }
@@ -644,18 +717,64 @@ mod tests {
         assert_eq!(parsed.name, "test");
     }
 
+    /// Seed a local bare registry remote containing `index` and return its
+    /// path. Publish tests must go through real git — a cache-only fixture
+    /// is how the missing-push bug stayed hidden (#78).
+    fn local_registry(tmp: &std::path::Path, index: &RegistryIndex) -> PathBuf {
+        let seed = tmp.join("seed");
+        std::fs::create_dir_all(&seed).unwrap();
+        index.save(&seed.join("index.json")).unwrap();
+        let repo = git2::Repository::init(&seed).unwrap();
+        let mut gidx = repo.index().unwrap();
+        gidx.add_path(Path::new("index.json")).unwrap();
+        gidx.write().unwrap();
+        let tree = repo.find_tree(gidx.write_tree().unwrap()).unwrap();
+        let sig = git2::Signature::now("t", "t@t").unwrap();
+        repo.commit(Some("HEAD"), &sig, &sig, "seed", &tree, &[])
+            .unwrap();
+        let bare = tmp.join("registry.git");
+        git2::build::RepoBuilder::new()
+            .bare(true)
+            .clone(seed.to_str().unwrap(), &bare)
+            .unwrap();
+        bare
+    }
+
+    #[test]
+    fn test_publish_module_pushes_to_remote() {
+        // #78 round-trip: a publication must reach the registry remote —
+        // a fresh consumer clone has to see it.
+        let tmp = tempfile::tempdir().unwrap();
+        let bare = local_registry(tmp.path(), &RegistryIndex::new("t", "t"));
+
+        // Publisher client publishes.
+        let publisher = RegistryClient::new(bare.to_str().unwrap(), tmp.path().join("cache-a"));
+        publisher
+            .publish_module(&PublishModuleParams {
+                name: "com.github.example.demo".to_string(),
+                version: "1.0.0".to_string(),
+                tag: "v1.0.0".to_string(),
+                commit: "0".repeat(40),
+                description: Some("probe".to_string()),
+                license: Some("MIT".to_string()),
+                repository: "https://github.com/example/demo".to_string(),
+            })
+            .unwrap();
+
+        // A fresh consumer (separate cache) must see the publication.
+        let consumer = RegistryClient::new(bare.to_str().unwrap(), tmp.path().join("cache-b"));
+        let index = consumer.update().unwrap();
+        assert!(
+            index.modules.contains_key("com.github.example.demo"),
+            "publication never reached the remote"
+        );
+    }
+
     #[test]
     fn test_publish_module_creates_entry() {
         let tmp = tempfile::tempdir().unwrap();
-        let cache_dir = tmp.path().to_path_buf();
-
-        // Create the registry index directory structure
-        let index_dir = cache_dir.join("registry").join("index");
-        std::fs::create_dir_all(&index_dir).unwrap();
-        let empty_index = RegistryIndex::new("test", "Test registry");
-        empty_index.save(&index_dir.join("index.json")).unwrap();
-
-        let client = RegistryClient::new("file:///unused", cache_dir);
+        let bare = local_registry(tmp.path(), &RegistryIndex::new("test", "Test registry"));
+        let client = RegistryClient::new(bare.to_str().unwrap(), tmp.path().join("cache"));
 
         let params = PublishModuleParams {
             name: "github.user.mylib".into(),
@@ -680,10 +799,6 @@ mod tests {
     #[test]
     fn test_publish_module_appends_version() {
         let tmp = tempfile::tempdir().unwrap();
-        let cache_dir = tmp.path().to_path_buf();
-
-        let index_dir = cache_dir.join("registry").join("index");
-        std::fs::create_dir_all(&index_dir).unwrap();
         let mut index = RegistryIndex::new("test", "Test");
         index.upsert_module(RegistryEntry {
             name: "github.user.mylib".into(),
@@ -705,9 +820,9 @@ mod tests {
             verified: false,
             deprecated: None,
         });
-        index.save(&index_dir.join("index.json")).unwrap();
+        let bare = local_registry(tmp.path(), &index);
+        let client = RegistryClient::new(bare.to_str().unwrap(), tmp.path().join("cache"));
 
-        let client = RegistryClient::new("file:///unused", cache_dir);
         let params = PublishModuleParams {
             name: "github.user.mylib".into(),
             version: "1.0.0".into(),

--- a/docs/plan-search-registry.md
+++ b/docs/plan-search-registry.md
@@ -1,8 +1,10 @@
 # Design Doc: `cmod search` Against a Real Index
 
-**Status:** Designed 2026-07 (issue #53). Implementation is deliberately
-deferred — this document records what exists, what is missing, and the
-phased path to a live index. Companion to
+**Status:** Phase 1 complete 2026-07 (issue #78) — the index repo is live at
+[cmod-registry/index](https://github.com/cmod-registry/index), seeded with
+the nine cmod-ecosystem ports; `cmod search` works end-to-end against it
+and the publish path now commits+pushes (it previously only edited the
+local cache). Phase 2 (PR-based submissions) is next (#79). Companion to
 [plan-crates-io-publishing.md](plan-crates-io-publishing.md) and RFC-0015
 (ecosystem governance).
 
@@ -25,9 +27,8 @@ The code side of a Git-hosted registry is implemented and tested in
 
 ## What is missing
 
-1. **The index repo itself.** `RegistryClient::default_url()` points at
-   `https://github.com/cmod-registry/index`, which does not exist. Every
-   default-configuration `cmod search` quietly falls back to local results.
+1. ~~**The index repo itself.**~~ **Done (phase 1):** the repo exists and
+   is seeded; default-configuration `cmod search` returns registry results.
 2. **A submission path for non-owners.** `publish_module` pushes directly —
    fine for a single maintainer, wrong for community submissions.
 3. **Scale/abuse story** — irrelevant until 1 and 2 exist.


### PR DESCRIPTION
## Summary

Closes #78 — registry phase 1, in two parts:

**The live registry (operational work, already done):**
- `cmod-registry/index` is live at the exact URL `default_url()` has always pointed to, seeded with the nine validated cmod-ecosystem ports — generated *through* `cmod-resolver`'s own `RegistryIndex` types (round-trip verified with the same loader clients use), plus `POLICY.md` derived from the `GovernancePolicy` defaults
- Verified end-to-end with the real binary: `cmod search spdlog/json/catch2` returns registry matches online and via the `--offline` cached path — the search feature has silently no-op'd since it was written; it's now live

**The code fix (this PR):** the phase-1 round-trip check exposed that **`publish_module` never pushed** — it upserted `index.json` into the local cache clone and stopped; the next pull silently discarded every publication. `cmod publish` with `[publish] registry` configured has never worked. Now: commit + push with credential-helper-aware auth, and a clear error when the publisher lacks write access.

The legacy publish tests fabricated a cache directory with no git whatsoever — exactly why this stayed hidden. They now run against a real local bare registry via a shared fixture, alongside the new `test_publish_module_pushes_to_remote` (TDD: watched fail with "publication never reached the remote").

Design doc updated: phase 1 marked complete, phase 2 (#79, PR-based submissions) queued.

## Validation

873 passed, 0 failed. Clippy (1.97) + fmt clean. Live `cmod search` output against github.com/cmod-registry/index verified from a clean cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Published modules now update the shared registry index, making new versions available through registry searches.
  * Registry publishing now preserves changes remotely instead of only updating local data.

* **Documentation**
  * Updated registry search documentation to reflect the live index and completed initial implementation phase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->