### PR TITLE
fix(vscode): pin cmod.binaryVersion to the real release

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -29,7 +29,7 @@
     "url": "https://github.com/satishbabariya/cmod"
   },
   "cmod": {
-    "binaryVersion": "0.1.0"
+    "binaryVersion": "0.1.0-alpha.3"
   },
   "activationEvents": [
     "workspaceContains:cmod.toml",


### PR DESCRIPTION
Release-workflow attempt 2 (post-lockfile-fix, #89): the universal VSIX now builds, but every platform job 404s at `Download cmod binary from release` — `package.json`'s `cmod.binaryVersion` is `"0.1.0"`, a release that has never existed. Pin it to `0.1.0-alpha.3`, whose seven platform archives are live.

After merge: re-point `vscode-v0.1.0` and re-run (attempt 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Visual Studio Code extension’s binary version metadata to the alpha 3 release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->