### PR TITLE
fix(release): build darwin-x64 on the free arm64 runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,9 @@ jobs:
             os: ubuntu-latest
             archive: tar.gz
           - target: x86_64-apple-darwin
-            os: macos-15-large
+            # Cross-compiled from the free arm64 runner — macos-*-large is a
+            # premium-billed pool whose availability proved flaky (alpha.4).
+            os: macos-14
             archive: tar.gz
           - target: aarch64-apple-darwin
             os: macos-14


### PR DESCRIPTION
The alpha.4 binary release failed twice on `Build (x86_64-apple-darwin)` with zero-step infrastructure failures — the `macos-15-large` premium runner pool (billed, capacity-limited) stopped scheduling after working earlier the same day. Expired logs on attempt 1; attempt 2 reproduced it deterministically.

Fix: cross-compile darwin-x64 from the free arm64 `macos-14` runner — the workflow already passes `targets:`/`--target` for every leg, so this is a runner-label swap.

After merge: re-point `v0.1.0-alpha.4` to pick up the fixed workflow (tag-triggered runs use the workflow at the tag ref) and let the release rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the macOS release build environment for improved compatibility with the x86_64 target.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->