### PR TITLE
feat(registry): phase 2 — PR-based community submissions

### DIFF
--- a/crates/cmod-cli/src/commands/mod.rs
+++ b/crates/cmod-cli/src/commands/mod.rs
@@ -17,6 +17,7 @@ pub mod plugin;
 #[allow(dead_code)]
 pub mod plugin_sandbox;
 pub mod publish;
+pub mod registry;
 pub mod remove;
 pub mod resolve;
 pub mod run;

--- a/crates/cmod-cli/src/commands/publish.rs
+++ b/crates/cmod-cli/src/commands/publish.rs
@@ -367,8 +367,29 @@ fn publish_to_registry(
         Err(e) => {
             shell.warn(format!("failed to publish to registry: {}", e));
             shell.note("the git tag was created successfully; registry publish can be retried");
+            // Without write access, the community path is a submission PR
+            // against the index repo — hand the user their ready-made entry.
+            let entry = cmod_resolver::registry::RegistryEntry::from_publish_params(
+                &params,
+                &chrono_free_timestamp(),
+            );
+            if let Ok(fragment) = serde_json::to_string_pretty(&entry) {
+                shell.note(format!(
+                    "no write access? open a PR against {} adding this entry to index.json \
+                     under \"modules\" (key: \"{}\"):\n{}",
+                    registry_url, entry.name, fragment
+                ));
+            }
         }
     }
+}
+
+/// Seconds-since-epoch timestamp string (no chrono dependency).
+fn chrono_free_timestamp() -> String {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs().to_string())
+        .unwrap_or_default()
 }
 
 /// Resolve HEAD commit hash.

--- a/crates/cmod-cli/src/commands/registry.rs
+++ b/crates/cmod-cli/src/commands/registry.rs
@@ -1,0 +1,42 @@
+//! `cmod registry` — registry index maintenance commands.
+//!
+//! `validate` is the gate the cmod-registry validation Action runs on
+//! submission PRs (#79): the exact governance rules from
+//! `validate_for_publishing`, plus the no-deletions policy when a base
+//! revision is supplied.
+
+use std::path::Path;
+
+use cmod_core::error::CmodError;
+use cmod_core::shell::Shell;
+use cmod_resolver::registry::{validate_index, validate_index_against_base, GovernancePolicy};
+use cmod_resolver::RegistryIndex;
+
+/// Run `cmod registry validate <path> [--against <base>]`.
+pub fn validate(path: &str, against: Option<&str>, shell: &Shell) -> Result<(), CmodError> {
+    let index = RegistryIndex::load(Path::new(path))?;
+
+    let mut violations = validate_index(&index, &GovernancePolicy::default());
+
+    if let Some(base_path) = against {
+        let base = RegistryIndex::load(Path::new(base_path))?;
+        violations.extend(validate_index_against_base(&index, &base));
+    }
+
+    if violations.is_empty() {
+        shell.status(
+            "Valid",
+            format!("{} ({} modules)", path, index.modules.len()),
+        );
+        return Ok(());
+    }
+
+    for v in &violations {
+        shell.error(v);
+    }
+    Err(CmodError::Other(format!(
+        "{} registry policy violation(s) in {}",
+        violations.len(),
+        path
+    )))
+}

--- a/crates/cmod-cli/src/main.rs
+++ b/crates/cmod-cli/src/main.rs
@@ -398,6 +398,12 @@ enum Commands {
 
     /// Start the LSP server for IDE integration
     Lsp,
+
+    /// Registry index maintenance (validation for submission PRs)
+    Registry {
+        #[command(subcommand)]
+        action: RegistryAction,
+    },
 }
 
 #[derive(Subcommand)]
@@ -439,6 +445,19 @@ enum PluginAction {
         /// Arguments to pass to the plugin (key=value pairs)
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
+    },
+}
+
+#[derive(Subcommand)]
+enum RegistryAction {
+    /// Validate a registry index.json against governance policy
+    Validate {
+        /// Path to the index.json to validate
+        path: String,
+        /// Base-revision index.json — additionally enforce the
+        /// no-deletions policy (yanks flip a flag, rows never disappear)
+        #[arg(long)]
+        against: Option<String>,
     },
 }
 
@@ -664,6 +683,11 @@ fn main() {
         Commands::EmitCmake => commands::build::emit_cmake(&shell),
         Commands::Migrate { from } => match from {
             MigrateFrom::Cmake { path } => commands::migrate::run(path, &shell),
+        },
+        Commands::Registry { action } => match action {
+            RegistryAction::Validate { path, against } => {
+                commands::registry::validate(&path, against.as_deref(), &shell)
+            }
         },
         Commands::Lsp => {
             let mut server = cmod_lsp::server::LspServer::new();

--- a/crates/cmod-cli/tests/cli_integration.rs
+++ b/crates/cmod-cli/tests/cli_integration.rs
@@ -2168,3 +2168,52 @@ fn test_migrate_cmake_existing_cmod_toml() {
         "should fail when cmod.toml already exists"
     );
 }
+
+/// #79: `cmod registry validate` gates index PRs — clean passes, violations
+/// and removals fail with actionable output.
+#[test]
+fn test_registry_validate_command() {
+    let tmp = TempDir::new().unwrap();
+
+    let good = r#"{"version":1,"name":"t","description":"t","updated_at":"now","modules":{
+      "com.github.x.y":{"name":"com.github.x.y","description":"d","repository":"https://github.com/x/y",
+        "versions":[{"version":"1.0.0","tag":"v1.0.0","commit":"cc","min_cpp_standard":null,"published_at":"now","yanked":false}],
+        "keywords":[],"category":null,"license":"MIT","authors":[],"updated_at":"now","verified":false,"deprecated":null}}}"#;
+    let bad = good.replace("\"license\":\"MIT\"", "\"license\":null");
+    fs::write(tmp.path().join("good.json"), good).unwrap();
+    fs::write(tmp.path().join("bad.json"), &bad).unwrap();
+    // base with an extra module that "removed.json" drops
+    let removed = good;
+    let base = good.replace(
+        "\"modules\":{",
+        r#""modules":{"com.github.x.gone":{"name":"com.github.x.gone","description":"d","repository":"https://github.com/x/g","versions":[{"version":"1.0.0","tag":"v1.0.0","commit":"cc","min_cpp_standard":null,"published_at":"now","yanked":false}],"keywords":[],"category":null,"license":"MIT","authors":[],"updated_at":"now","verified":false,"deprecated":null},"#,
+    );
+    fs::write(tmp.path().join("base.json"), base).unwrap();
+    fs::write(tmp.path().join("removed.json"), removed).unwrap();
+
+    let ok = run_cmod(tmp.path(), &["registry", "validate", "good.json"]);
+    assert!(
+        ok.status.success(),
+        "clean index must pass: {}",
+        String::from_utf8_lossy(&ok.stderr)
+    );
+
+    let fail = run_cmod(tmp.path(), &["registry", "validate", "bad.json"]);
+    assert!(!fail.status.success(), "violations must fail");
+    assert!(String::from_utf8_lossy(&fail.stderr)
+        .to_lowercase()
+        .contains("license"));
+
+    let gone = run_cmod(
+        tmp.path(),
+        &[
+            "registry",
+            "validate",
+            "removed.json",
+            "--against",
+            "base.json",
+        ],
+    );
+    assert!(!gone.status.success(), "removals must fail");
+    assert!(String::from_utf8_lossy(&gone.stderr).contains("com.github.x.gone"));
+}

--- a/crates/cmod-resolver/src/registry.rs
+++ b/crates/cmod-resolver/src/registry.rs
@@ -40,6 +40,34 @@ pub struct RegistryEntry {
     pub deprecated: Option<String>,
 }
 
+impl RegistryEntry {
+    /// Build the entry a publication would create — shared by
+    /// `RegistryClient::publish_module` and the `cmod publish` PR-fragment
+    /// fallback so the two can never drift (#79).
+    pub fn from_publish_params(params: &PublishModuleParams, now: &str) -> Self {
+        RegistryEntry {
+            name: params.name.clone(),
+            description: params.description.clone(),
+            repository: params.repository.clone(),
+            versions: vec![RegistryVersion {
+                version: params.version.clone(),
+                tag: params.tag.clone(),
+                commit: params.commit.clone(),
+                min_cpp_standard: None,
+                published_at: now.to_string(),
+                yanked: false,
+            }],
+            keywords: Vec::new(),
+            category: None,
+            license: params.license.clone(),
+            authors: Vec::new(),
+            updated_at: now.to_string(),
+            verified: false,
+            deprecated: None,
+        }
+    }
+}
+
 /// A specific version of a module in the registry.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RegistryVersion {
@@ -251,20 +279,7 @@ impl RegistryClient {
                 entry.license = Some(lic.clone());
             }
         } else {
-            let entry = RegistryEntry {
-                name: params.name.clone(),
-                description: params.description.clone(),
-                repository: params.repository.clone(),
-                versions: vec![new_version],
-                keywords: Vec::new(),
-                category: None,
-                license: params.license.clone(),
-                authors: Vec::new(),
-                updated_at: now,
-                verified: false,
-                deprecated: None,
-            };
-            index.upsert_module(entry);
+            index.upsert_module(RegistryEntry::from_publish_params(params, &now));
         }
 
         let repo_path = self.cache_dir.join("registry").join("index");
@@ -450,6 +465,69 @@ impl Default for NamingRules {
             require_reverse_domain: true,
         }
     }
+}
+
+/// Validate every entry in a registry index against governance policy.
+///
+/// Returns human-readable violations (empty = valid). This is the same rule
+/// set `validate_for_publishing` applies to individual submissions, plus
+/// structural checks — the registry's validation Action runs exactly this
+/// via `cmod registry validate` (#79).
+pub fn validate_index(index: &RegistryIndex, policy: &GovernancePolicy) -> Vec<String> {
+    let mut violations = Vec::new();
+    for (key, entry) in &index.modules {
+        if key != &entry.name {
+            violations.push(format!(
+                "{}: map key does not match entry name '{}'",
+                key, entry.name
+            ));
+        }
+        if entry.repository.is_empty() {
+            violations.push(format!("{}: repository URL is empty", entry.name));
+        }
+        if entry.versions.is_empty() {
+            violations.push(format!("{}: no versions listed", entry.name));
+        }
+        for v in &entry.versions {
+            for violation in validate_for_publishing(
+                &entry.name,
+                &v.version,
+                entry.description.as_deref(),
+                entry.license.as_deref(),
+                policy,
+            ) {
+                violations.push(format!("{} v{}: {}", entry.name, v.version, violation));
+            }
+        }
+    }
+    violations
+}
+
+/// Validate an updated index against its base revision.
+///
+/// Policy (POLICY.md): listings and version rows are never deleted — a yank
+/// flips the `yanked` flag so existing lockfiles keep resolving.
+pub fn validate_index_against_base(new: &RegistryIndex, base: &RegistryIndex) -> Vec<String> {
+    let mut violations = Vec::new();
+    for (name, base_entry) in &base.modules {
+        match new.modules.get(name) {
+            None => violations.push(format!(
+                "{}: module removed — yank versions instead of deleting listings",
+                name
+            )),
+            Some(new_entry) => {
+                for bv in &base_entry.versions {
+                    if !new_entry.versions.iter().any(|nv| nv.version == bv.version) {
+                        violations.push(format!(
+                            "{} v{}: version row removed — set \"yanked\": true instead",
+                            name, bv.version
+                        ));
+                    }
+                }
+            }
+        }
+    }
+    violations
 }
 
 /// Validate a module against governance policy before publishing.
@@ -715,6 +793,112 @@ mod tests {
         let json = serde_json::to_string(&index).unwrap();
         let parsed: RegistryIndex = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed.name, "test");
+    }
+
+    #[test]
+    fn test_entry_from_params_matches_publish_shape() {
+        let params = PublishModuleParams {
+            name: "com.github.x.y".to_string(),
+            version: "1.2.0".to_string(),
+            tag: "v1.2.0".to_string(),
+            commit: "a".repeat(40),
+            description: Some("d".to_string()),
+            license: Some("MIT".to_string()),
+            repository: "https://github.com/x/y".to_string(),
+        };
+        let entry = RegistryEntry::from_publish_params(&params, "ts");
+        assert_eq!(entry.name, "com.github.x.y");
+        assert_eq!(entry.versions.len(), 1);
+        assert_eq!(entry.versions[0].tag, "v1.2.0");
+        assert_eq!(entry.updated_at, "ts");
+        assert!(!entry.verified);
+    }
+
+    // --- index validation for registry phase 2 (#79) ---
+
+    fn seeded_entry(name: &str) -> RegistryEntry {
+        RegistryEntry {
+            name: name.to_string(),
+            description: Some("desc".to_string()),
+            repository: "https://github.com/x/y".to_string(),
+            versions: vec![RegistryVersion {
+                version: "1.0.0".to_string(),
+                tag: "v1.0.0".to_string(),
+                commit: "c".repeat(40),
+                min_cpp_standard: None,
+                published_at: "now".to_string(),
+                yanked: false,
+            }],
+            keywords: vec![],
+            category: None,
+            license: Some("MIT".to_string()),
+            authors: vec![],
+            updated_at: "now".to_string(),
+            verified: false,
+            deprecated: None,
+        }
+    }
+
+    #[test]
+    fn test_validate_index_clean() {
+        let mut idx = RegistryIndex::new("t", "t");
+        idx.upsert_module(seeded_entry("com.github.x.y"));
+        assert!(validate_index(&idx, &GovernancePolicy::default()).is_empty());
+    }
+
+    #[test]
+    fn test_validate_index_flags_violations() {
+        let mut idx = RegistryIndex::new("t", "t");
+        let mut banned = seeded_entry("std.core");
+        banned.license = None;
+        banned.versions[0].version = "not-semver".to_string();
+        idx.upsert_module(banned);
+        let violations = validate_index(&idx, &GovernancePolicy::default());
+        let joined = violations.join("\n");
+        assert!(joined.contains("std.core"), "banned name: {joined}");
+        assert!(
+            joined.to_lowercase().contains("license"),
+            "license: {joined}"
+        );
+        assert!(
+            joined.to_lowercase().contains("semver") || joined.contains("not-semver"),
+            "semver: {joined}"
+        );
+    }
+
+    #[test]
+    fn test_validate_index_against_base_rejects_removals() {
+        let mut base = RegistryIndex::new("t", "t");
+        base.upsert_module(seeded_entry("com.github.x.a"));
+        let mut b_entry = seeded_entry("com.github.x.b");
+        b_entry.versions.push(RegistryVersion {
+            version: "1.1.0".to_string(),
+            tag: "v1.1.0".to_string(),
+            commit: "d".repeat(40),
+            min_cpp_standard: None,
+            published_at: "now".to_string(),
+            yanked: false,
+        });
+        base.upsert_module(b_entry.clone());
+
+        // New index drops module a and removes a version row of b
+        let mut new = RegistryIndex::new("t", "t");
+        let mut b_short = b_entry.clone();
+        b_short.versions.pop();
+        new.upsert_module(b_short);
+
+        let violations = validate_index_against_base(&new, &base);
+        let joined = violations.join("\n");
+        assert!(
+            joined.contains("com.github.x.a"),
+            "module removal: {joined}"
+        );
+        assert!(joined.contains("1.1.0"), "version removal: {joined}");
+
+        // Yank-flag flips are allowed
+        let mut yanked = base.clone();
+        yanked.modules.get_mut("com.github.x.b").unwrap().versions[1].yanked = true;
+        assert!(validate_index_against_base(&yanked, &base).is_empty());
     }
 
     /// Seed a local bare registry remote containing `index` and return its

--- a/docs/guide/cli-reference.md
+++ b/docs/guide/cli-reference.md
@@ -555,6 +555,19 @@ List workspace members.
 cmod workspace list
 ```
 
+### `cmod registry validate`
+
+Validate a registry `index.json` against governance policy (the same rules
+`cmod publish` submissions face). Used by the cmod-registry validation CI.
+
+```
+cmod registry validate <PATH> [--against <BASE>]
+```
+
+`--against` additionally enforces the no-deletions policy: listings and
+version rows may never be removed relative to the base revision (yanks flip
+`"yanked": true`).
+
 ### `cmod workspace add`
 
 Add a member to the workspace.

--- a/docs/plan-search-registry.md
+++ b/docs/plan-search-registry.md
@@ -4,7 +4,7 @@
 [cmod-registry/index](https://github.com/cmod-registry/index), seeded with
 the nine cmod-ecosystem ports; `cmod search` works end-to-end against it
 and the publish path now commits+pushes (it previously only edited the
-local cache). Phase 2 (PR-based submissions) is next (#79). Companion to
+local cache). Phase 2 (PR-based submissions) shipped 2026-07: `cmod publish` prints a ready-made entry fragment when it lacks push access, and the index repo's **Validate submission** Action runs `cmod registry validate` (the client's own rules + no-deletions policy) on every `index.json` PR. Companion to
 [plan-crates-io-publishing.md](plan-crates-io-publishing.md) and RFC-0015
 (ecosystem governance).
 


### PR DESCRIPTION
## Summary

Closes #79 — registry phase 2, per `docs/plan-search-registry.md`.

**cmod side (this PR):**
- **`cmod registry validate <path> [--against <base>]`** — validates an entire `index.json` with the *same* `validate_for_publishing` rules submissions face (banned names, semver, license, description) plus structural checks, and with `--against`, the no-deletions policy (listings/version rows never disappear; yanks flip the flag). Exit 1 with per-violation stderr.
- **`cmod publish` PR fallback** — without push access it now prints a ready-made `RegistryEntry` JSON fragment and PR instructions. Entry construction is factored into `RegistryEntry::from_publish_params`, shared with `publish_module`, so the fragment can never drift from what a direct publish writes.

**Index repo side (shipped to `cmod-registry/index` directly):** a `Validate submission` Action running `cmod registry validate` on every `index.json` PR (base snapshot for the no-deletions check), a submission PR template, and POLICY.md's flow update.

## Verification

- TDD across all pieces (validators, shared constructor, CLI) — every test watched fail first
- **Live index validates**: `Valid (9 modules)` against the deployed registry
- **Gate probed for real**: [cmod-registry/index#1](https://github.com/cmod-registry/index/pull/1) deliberately removes a listing and strips a license — the Action must reject it; result posted here before merge

878 passed, 0 failed. Clippy (1.97) + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `cmod registry validate` to check registry indexes for governance violations.
  * Added optional base-index comparison to detect unauthorized module or version removals.
  * Publish failures now provide a ready-to-use registry index entry and contribution instructions.

* **Documentation**
  * Added CLI reference documentation and updated registry workflow status details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->