### PR TITLE
feat(publish): explain the tag-only path when no registry is configured

### DIFF
--- a/crates/cmod-cli/src/commands/publish.rs
+++ b/crates/cmod-cli/src/commands/publish.rs
@@ -135,9 +135,21 @@ pub fn run(
     }
 
     // Step 8: Publish to registry if configured
-    if let Some(ref publish) = config.manifest.publish {
-        if let Some(ref registry_url) = publish.registry {
+    let registry_url = config
+        .manifest
+        .publish
+        .as_ref()
+        .and_then(|p| p.registry.as_ref());
+    match registry_url {
+        Some(registry_url) => {
             publish_to_registry(name, version, &tag, &config, registry_url, shell);
+        }
+        None => {
+            shell.note(
+                "no [publish] registry configured — the release is tag-only; add \
+                 [publish] registry = \"https://github.com/cmod-registry/index\" \
+                 to cmod.toml to list this module for `cmod search`",
+            );
         }
     }
 

--- a/crates/cmod-cli/tests/cli_integration.rs
+++ b/crates/cmod-cli/tests/cli_integration.rs
@@ -2217,3 +2217,50 @@ fn test_registry_validate_command() {
     assert!(!gone.status.success(), "removals must fail");
     assert!(String::from_utf8_lossy(&gone.stderr).contains("com.github.x.gone"));
 }
+
+/// #101: publishing without [publish] registry must say what was done
+/// (tag) and what was skipped (registry listing), not silently omit it.
+#[test]
+fn test_publish_without_registry_explains_skip() {
+    let tmp = TempDir::new().unwrap();
+    run_cmod(tmp.path(), &["init", "--name", "pubux"]);
+    // publish's governance pre-check requires description + license
+    let manifest = fs::read_to_string(tmp.path().join("cmod.toml")).unwrap();
+    fs::write(
+        tmp.path().join("cmod.toml"),
+        manifest.replace(
+            "[package]",
+            "[package]\ndescription = \"t\"\nlicense = \"MIT\"",
+        ),
+    )
+    .unwrap();
+
+    // publish requires a git repo with a commit
+    let git = |args: &[&str]| {
+        Command::new("git")
+            .args(args)
+            .current_dir(tmp.path())
+            .env("GIT_AUTHOR_NAME", "t")
+            .env("GIT_AUTHOR_EMAIL", "t@t")
+            .env("GIT_COMMITTER_NAME", "t")
+            .env("GIT_COMMITTER_EMAIL", "t@t")
+            .output()
+            .expect("git")
+    };
+    git(&["init", "-q"]);
+    git(&["add", "-A"]);
+    git(&["commit", "-qm", "init"]);
+
+    let output = run_cmod(tmp.path(), &["publish"]);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "publish should succeed: {}",
+        stderr
+    );
+    assert!(
+        stderr.contains("no [publish] registry configured"),
+        "must explain the skipped registry listing, got: {}",
+        stderr
+    );
+}

--- a/crates/cmod-cli/tests/cli_integration.rs
+++ b/crates/cmod-cli/tests/cli_integration.rs
@@ -2248,6 +2248,10 @@ fn test_publish_without_registry_explains_skip() {
             .expect("git")
     };
     git(&["init", "-q"]);
+    // repo-local identity: the publish subprocess creates an annotated tag,
+    // and CI runners have no global git identity
+    git(&["config", "user.name", "t"]);
+    git(&["config", "user.email", "t@t"]);
     git(&["add", "-A"]);
     git(&["commit", "-qm", "init"]);
 


### PR DESCRIPTION
Closes #101 — `cmod publish` without `[publish] registry` now notes that the release is tag-only and shows the one-liner to opt into registry listing, instead of silently omitting the step.

TDD: integration test drives a real `cmod publish` in a temp git repo (governance-compliant manifest) and asserts the explanation; watched fail first — which also surfaced that the *first* failure mode a new publisher hits is the governance pre-check, worth knowing for docs later.

879 passed, 0 failed. Clippy + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)