### PR TITLE
ci: build cmod before entering the VS dev env in the MSVC job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,9 +163,14 @@ jobs:
         with:
           shared-key: stable
           save-if: ${{ github.ref == 'refs/heads/main' }}
-      - uses: ilammy/msvc-dev-cmd@v1
+      # Build BEFORE entering the VS dev environment: msvc-dev-cmd exports
+      # INCLUDE/LIB, which the native-dep build scripts (vendored openssl,
+      # libgit2) track via rerun-if-env-changed — building under the same
+      # env the shared cache was fingerprinted with keeps restores warm
+      # (#100: 527s -> expected ~2m). cc-rs finds MSVC via vswhere anyway.
       - name: Build cmod
         run: cargo build -p cmod-cli
+      - uses: ilammy/msvc-dev-cmd@v1
       - name: End-to-end module build with MSVC
         shell: bash
         run: |


### PR DESCRIPTION
Closes #100 — diagnosed from live main-run telemetry:

| evidence | value |
|---|---|
| MSVC job cache restore | `full match: true` (same 172 MB key the Test job saved) |
| …yet `Build cmod` | **527s** (full native-dep rebuild) |
| GCC job (control) | 119s build — the normal Swatinem baseline (deps cached, workspace crates rebuild by design) |

**Root cause:** `ilammy/msvc-dev-cmd` ran *between* cache restore and build, exporting `INCLUDE`/`LIB` — env vars the native build scripts (vendored openssl, libgit2-sys) track via `rerun-if-env-changed`. Fingerprints mismatched the cache (saved by the Test job outside the dev env), so the expensive C compiles re-ran on every run.

**Fix:** build before entering the dev env (cc-rs locates MSVC via vswhere regardless — that's exactly how the Test job compiles), then activate the dev env only for the E2E step where *cmod* needs `cl` on PATH. Expected: ~527s → ~2m, on every PR's critical path.

Verification: this PR's own MSVC job runs the reordered steps; I'll post its Build-step duration before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)