### PR TITLE
ci: real-world header-only consumers in the MSVC E2E job

### DIFF
--- a/.github/msvc-smoke/cli11.cpp
+++ b/.github/msvc-smoke/cli11.cpp
@@ -1,0 +1,10 @@
+#include <CLI/CLI.hpp>
+#include <cstdio>
+int main(int argc, char** argv) {
+    CLI::App app{"smoke"};
+    int count = 1;
+    app.add_option("--count", count);
+    CLI11_PARSE(app, argc, argv);
+    std::printf("cli11 works: %d\n", count);
+    return 0;
+}

--- a/.github/msvc-smoke/json.cpp
+++ b/.github/msvc-smoke/json.cpp
@@ -1,0 +1,7 @@
+#include <nlohmann/json.hpp>
+#include <cstdio>
+int main() {
+    auto j = nlohmann::json::parse("{\"msvc\":42}");
+    std::printf("json works: %d\n", j["msvc"].get<int>());
+    return 0;
+}

--- a/.github/msvc-smoke/rapidjson.cpp
+++ b/.github/msvc-smoke/rapidjson.cpp
@@ -1,0 +1,13 @@
+#include <rapidjson/document.h>
+#include <rapidjson/writer.h>
+#include <rapidjson/stringbuffer.h>
+#include <cstdio>
+int main() {
+    rapidjson::Document d;
+    d.Parse("{\"k\":7}");
+    rapidjson::StringBuffer sb;
+    rapidjson::Writer<rapidjson::StringBuffer> w(sb);
+    d.Accept(w);
+    std::printf("rapidjson works: %s\n", sb.GetString());
+    return 0;
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,6 +183,31 @@ jobs:
           test -f build/debug/pcm/local_msvcdemo.ifc
           ./build/debug/msvcdemo
 
+      # Real-world header-only ecosystem ports as MSVC consumers (#99).
+      # Static-lib ports are excluded for now: their manifests carry
+      # gcc/clang-style defines that MSVC needs spelled differently.
+      - name: Real-world header-only consumers (MSVC)
+        shell: bash
+        run: |
+          set -x
+          CMOD=$GITHUB_WORKSPACE/target/debug/cmod
+
+          consumer() { # name repo
+            mkdir "/c/rw-$1" && cd "/c/rw-$1"
+            $CMOD init --name consumer
+            sed -i 's/compiler = "clang"/compiler = "msvc"/' cmod.toml
+            $CMOD add "github.com/cmod-ecosystem/$2" --branch cmod-support
+            cp "$GITHUB_WORKSPACE/.github/msvc-smoke/$1.cpp" src/main.cpp
+            $CMOD resolve
+            $CMOD build --verbose
+            ./build/debug/consumer
+            cd /
+          }
+
+          consumer json json
+          consumer cli11 CLI11
+          consumer rapidjson rapidjson
+
   cross-target:
     name: Cross-target smoke
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes #99 — the MSVC backend gets real-library coverage beyond the synthetic module project: the `json`, `CLI11`, and `rapidjson` cmod-ecosystem ports each run the full `init → add → resolve → build → run` pipeline under `compiler = "msvc"` on every PR, with consumer sources checked in under `.github/msvc-smoke/`.

Scope per the issue: header-only only for now — the static-lib ports (`fmt`, `spdlog`) carry gcc/clang-style `-D` defines in `extra_flags` that MSVC wants as `/D`; that flag-translation question is future work.

Affordable because of #104: the job's build step is ~30s warm, so three consumers add ~1–2 minutes.

**Self-verifying:** this PR's own MSVC job runs the new consumers — result below before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)